### PR TITLE
Constrain sizes of solid tile and alpha tile batches being sent to the GPU (try 2).

### DIFF
--- a/renderer/src/builder.rs
+++ b/renderer/src/builder.rs
@@ -118,10 +118,10 @@ impl<'a> SceneBuilder<'a> {
         let path_count = self.scene.paths.len() as u32;
         let solid_tiles = self.z_buffer.build_solid_tiles(&self.scene.paths, 0..path_count);
         if !solid_tiles.is_empty() {
-            self.listener.send(RenderCommand::SolidTile(solid_tiles));
+            self.listener.send(RenderCommand::AddSolidTiles(solid_tiles));
         }
         if !alpha_tiles.is_empty() {
-            self.listener.send(RenderCommand::AlphaTile(alpha_tiles));
+            self.listener.send(RenderCommand::AddAlphaTiles(alpha_tiles));
         }
     }
 
@@ -129,6 +129,8 @@ impl<'a> SceneBuilder<'a> {
         self.listener.send(RenderCommand::FlushFills);
         self.cull_alpha_tiles(&mut alpha_tiles);
         self.pack_alpha_tiles(alpha_tiles);
+        self.listener.send(RenderCommand::FlushSolidTiles);
+        self.listener.send(RenderCommand::FlushAlphaTiles);
     }
 }
 

--- a/renderer/src/gpu_data.rs
+++ b/renderer/src/gpu_data.rs
@@ -31,8 +31,10 @@ pub enum RenderCommand {
     AddPaintData(PaintData),
     AddFills(Vec<FillBatchPrimitive>),
     FlushFills,
-    AlphaTile(Vec<AlphaTileBatchPrimitive>),
-    SolidTile(Vec<SolidTileBatchPrimitive>),
+    AddAlphaTiles(Vec<AlphaTileBatchPrimitive>),
+    FlushAlphaTiles,
+    AddSolidTiles(Vec<SolidTileBatchPrimitive>),
+    FlushSolidTiles,
     Finish { build_time: Duration },
 }
 
@@ -99,12 +101,14 @@ impl Debug for RenderCommand {
             }
             RenderCommand::AddFills(ref fills) => write!(formatter, "AddFills(x{})", fills.len()),
             RenderCommand::FlushFills => write!(formatter, "FlushFills"),
-            RenderCommand::AlphaTile(ref tiles) => {
-                write!(formatter, "AlphaTile(x{})", tiles.len())
+            RenderCommand::AddAlphaTiles(ref tiles) => {
+                write!(formatter, "AddAlphaTiles(x{})", tiles.len())
             }
-            RenderCommand::SolidTile(ref tiles) => {
-                write!(formatter, "SolidTile(x{})", tiles.len())
+            RenderCommand::FlushAlphaTiles => write!(formatter, "FlushAlphaTiles"),
+            RenderCommand::AddSolidTiles(ref tiles) => {
+                write!(formatter, "AddSolidTiles(x{})", tiles.len())
             }
+            RenderCommand::FlushSolidTiles => write!(formatter, "FlushSolidTiles"),
             RenderCommand::Finish { .. } => write!(formatter, "Finish"),
         }
     }


### PR DESCRIPTION
It seems that the last PR trying to do this had issues with zoom: https://github.com/pcwalton/pathfinder/pull/148

I redid things, and am unable to reproduce the zoom error: zoom works fine for me. So, I am no longer sure if the issue still persists, but I am also not sure what I did (I doubt I did anything) to fix it. 

Can you try to clone my fork and try out the master branch? 