### PR TITLE
Get magicleap working again

### DIFF
--- a/demo/common/src/lib.rs
+++ b/demo/common/src/lib.rs
@@ -13,7 +13,10 @@
 #[macro_use]
 extern crate log;
 
-use crate::camera::{Camera, Mode};
+// Mode is used in Options, so has to be public
+pub use crate::camera::Mode;
+
+use crate::camera::Camera;
 use crate::concurrent::DemoExecutor;
 use crate::device::{GroundProgram, GroundVertexArray};
 use crate::ui::{DemoUIModel, DemoUIPresenter, ScreenshotInfo, ScreenshotType, UIAction};

--- a/demo/common/src/renderer.rs
+++ b/demo/common/src/renderer.rs
@@ -149,6 +149,8 @@ impl<W> DemoApp<W> where W: Window {
         debug!("modelview transform={:?}", modelview_transform);
 
         let viewport = self.window.viewport(View::Stereo(render_scene_index));
+        self.window.make_current(View::Stereo(render_scene_index));
+
         self.renderer
             .replace_dest_framebuffer(DestFramebuffer::Default {
                 viewport,

--- a/demo/common/src/window.rs
+++ b/demo/common/src/window.rs
@@ -34,7 +34,9 @@ pub trait Window {
     fn present_open_svg_dialog(&mut self);
     fn run_save_dialog(&self, extension: &str) -> Result<PathBuf, ()>;
 
-    fn adjust_thread_pool_settings(&self, _: &mut ThreadPoolBuilder) {}
+    fn adjust_thread_pool_settings(&self, builder: ThreadPoolBuilder) -> ThreadPoolBuilder {
+        builder
+    }
 }
 
 pub enum Event {

--- a/demo/magicleap/src/lib.rs
+++ b/demo/magicleap/src/lib.rs
@@ -20,7 +20,6 @@ use egl::EGLSurface;
 
 use gl::types::GLuint;
 
-use log::debug;
 use log::info;
 
 use pathfinder_demo::DemoApp;

--- a/demo/magicleap/src/lib.rs
+++ b/demo/magicleap/src/lib.rs
@@ -29,8 +29,8 @@ use pathfinder_demo::BackgroundColor;
 use pathfinder_demo::Mode;
 use pathfinder_demo::window::Event;
 use pathfinder_demo::window::SVGPath;
-use pathfinder_geometry::basic::point::Point2DF;
-use pathfinder_geometry::basic::point::Point2DI;
+use pathfinder_geometry::basic::vector::Vector2F;
+use pathfinder_geometry::basic::vector::Vector2I;
 use pathfinder_geometry::basic::rect::RectI;
 use pathfinder_geometry::basic::transform2d::Transform2DF;
 use pathfinder_geometry::color::ColorF;
@@ -190,10 +190,10 @@ pub unsafe extern "C" fn magicleap_pathfinder_render(pf: *mut c_void, options: *
         let mut height = 0;
         egl::query_surface(options.display, options.surface, egl::EGL_WIDTH, &mut width);
         egl::query_surface(options.display, options.surface, egl::EGL_HEIGHT, &mut height);
-        let size = Point2DI::new(width, height);
+        let size = Vector2I::new(width, height);
 
-        let viewport_origin = Point2DI::new(options.viewport[0] as i32, options.viewport[1] as i32);
-        let viewport_size = Point2DI::new(options.viewport[2] as i32, options.viewport[3] as i32);
+        let viewport_origin = Vector2I::new(options.viewport[0] as i32, options.viewport[1] as i32);
+        let viewport_size = Vector2I::new(options.viewport[2] as i32, options.viewport[3] as i32);
         let viewport = RectI::new(viewport_origin, viewport_size);
 
         let bg_color = ColorF(F32x4::new(options.bg_color[0], options.bg_color[1], options.bg_color[2], options.bg_color[3]));
@@ -216,12 +216,12 @@ pub unsafe extern "C" fn magicleap_pathfinder_render(pf: *mut c_void, options: *
         let scale = i32::min(viewport_size.x(), viewport_size.y()) as f32 /
             f32::max(svg.scene.bounds().size().x(), svg.scene.bounds().size().y());
         let transform = Transform2DF::from_translation(svg.scene.bounds().size().scale(-0.5))
-            .post_mul(&Transform2DF::from_scale(Point2DF::splat(scale)))
+            .post_mul(&Transform2DF::from_scale(Vector2F::splat(scale)))
             .post_mul(&Transform2DF::from_translation(viewport_size.to_f32().scale(0.5)));
             
         let render_options = RenderOptions {
             transform: RenderTransform::Transform2D(transform),
-            dilation: Point2DF::default(),
+            dilation: Vector2F::default(),
             subpixel_aa_enabled: false,
         };
 

--- a/demo/magicleap/src/magicleap.rs
+++ b/demo/magicleap/src/magicleap.rs
@@ -42,7 +42,6 @@ use gl::types::GLuint;
 use log;
 use log::debug;
 use log::info;
-use log::warn;
 
 use pathfinder_demo::window::Event;
 use pathfinder_demo::window::OcularTransform;

--- a/demo/magicleap/src/magicleap.rs
+++ b/demo/magicleap/src/magicleap.rs
@@ -42,19 +42,19 @@ use gl::types::GLuint;
 use log;
 use log::debug;
 use log::info;
+use log::warn;
 
-use pathfinder_demo::window::CameraTransform;
 use pathfinder_demo::window::Event;
+use pathfinder_demo::window::OcularTransform;
 use pathfinder_demo::window::View;
 use pathfinder_demo::window::Window;
 use pathfinder_demo::window::WindowSize;
-use pathfinder_geometry::basic::point::Point2DI32;
-use pathfinder_geometry::basic::point::Point2DF32;
-use pathfinder_geometry::basic::rect::RectF32;
-use pathfinder_geometry::basic::rect::RectI32;
+use pathfinder_geometry::basic::point::Point2DI;
+use pathfinder_geometry::basic::point::Point2DF;
+use pathfinder_geometry::basic::rect::RectF;
+use pathfinder_geometry::basic::rect::RectI;
 use pathfinder_geometry::basic::transform3d::Perspective;
-use pathfinder_geometry::basic::transform3d::Transform3DF32;
-use pathfinder_geometry::distortion::BarrelDistortionCoefficients;
+use pathfinder_geometry::basic::transform3d::Transform3DF;
 use pathfinder_geometry::util;
 use pathfinder_gl::GLVersion;
 use pathfinder_gpu::resources::FilesystemResourceLoader;
@@ -76,12 +76,12 @@ use std::time::Duration;
 pub struct MagicLeapWindow {
     framebuffer_id: GLuint,
     graphics_client: MLHandle,
-    size: Point2DI32,
+    size: Point2DI,
     virtual_camera_array: MLGraphicsVirtualCameraInfoArray,
-    initial_camera_transform: Option<Transform3DF32>,
+    initial_camera_transform: Option<Transform3DF>,
     frame_handle: MLHandle,
     resource_loader: FilesystemResourceLoader,
-    pose_event: Option<Vec<CameraTransform>>,
+    pose_event: Option<Vec<OcularTransform>>,
     running: bool,
     in_frame: bool,
 }
@@ -103,10 +103,6 @@ impl Window for MagicLeapWindow {
         thread_pool_builder.start_handler(|id| unsafe { init_scene_thread(id) })
     }
 
-    fn mouse_position(&self) -> Point2DI32 {
-        Point2DI32::new(0, 0)
-    }
-
     fn create_user_event_id (&self) -> u32 {
         0
     }
@@ -121,12 +117,8 @@ impl Window for MagicLeapWindow {
         Err(())
     }
 
-    fn viewport(&self, _view: View) -> RectI32 {
-        RectI32::new(Point2DI32::default(), self.size)
-    }
-
-    fn barrel_distortion_coefficients(&self) -> BarrelDistortionCoefficients {
-        BarrelDistortionCoefficients { k0: 0.0, k1: 0.0 }
+    fn viewport(&self, _view: View) -> RectI {
+        RectI::new(Point2DI::default(), self.size)
     }
 
     fn make_current(&mut self, view: View) {
@@ -142,6 +134,7 @@ impl Window for MagicLeapWindow {
         let virtual_camera = self.virtual_camera_array.virtual_cameras[eye];
         let layer_id = virtual_camera.virtual_camera_name as i32;
         unsafe {
+            gl::BindFramebuffer(gl::FRAMEBUFFER, self.framebuffer_id);
             gl::FramebufferTextureLayer(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, color_id, 0, layer_id);
             gl::FramebufferTextureLayer(gl::FRAMEBUFFER, gl::DEPTH_ATTACHMENT, depth_id, 0, layer_id);
             gl::Viewport(viewport.x as i32, viewport.y as i32, viewport.w as i32, viewport.h as i32);
@@ -192,7 +185,7 @@ impl MagicLeapWindow {
         MagicLeapWindow {
             framebuffer_id,
             graphics_client,
-            size: Point2DI32::new(max_width, max_height),
+            size: Point2DI::new(max_width, max_height),
             frame_handle: ML_HANDLE_INVALID,
             virtual_camera_array,
             initial_camera_transform: None,
@@ -215,12 +208,12 @@ impl MagicLeapWindow {
     }
 
     pub fn try_get_event(&mut self) -> Option<Event> {
-        self.pose_event.take().map(Event::CameraTransforms)
+        self.pose_event.take().map(Event::SetEyeTransforms)
     }
 
     fn begin_frame(&mut self) {
         if !self.in_frame {
-             debug!("PF beginning frame");
+            debug!("PF beginning frame");
             let mut params = unsafe { mem::zeroed() };
             unsafe {
                 gl::BindFramebuffer(gl::FRAMEBUFFER, self.framebuffer_id);
@@ -242,22 +235,22 @@ impl MagicLeapWindow {
             }
             let virtual_camera_array = &self.virtual_camera_array;
             let initial_camera = self.initial_camera_transform.get_or_insert_with(|| {
-                let initial_offset = Transform3DF32::from_translation(0.0, 0.0, 1.0);
+                let initial_offset = Transform3DF::from_translation(0.0, 0.0, 1.0);
 	        let mut camera = virtual_camera_array.virtual_cameras[0].transform;
 		for i in 1..virtual_camera_array.num_virtual_cameras {
 		    let next = virtual_camera_array.virtual_cameras[i as usize].transform;
 		    camera = camera.lerp(next, 1.0 / (i as f32 + 1.0));
 		}
-		Transform3DF32::from(camera).post_mul(&initial_offset)
+		Transform3DF::from(camera).post_mul(&initial_offset)
             });
             let camera_transforms = (0..virtual_camera_array.num_virtual_cameras)
                 .map(|i| {
 		    let camera = &virtual_camera_array.virtual_cameras[i as usize];
-                    let projection = Transform3DF32::from(camera.projection);
-                    let size = RectI32::from(virtual_camera_array.viewport).size();
+                    let projection = Transform3DF::from(camera.projection);
+                    let size = RectI::from(virtual_camera_array.viewport).size();
                     let perspective = Perspective::new(&projection, size);
-                    let view = Transform3DF32::from(camera.transform).inverse().post_mul(initial_camera);
-                    CameraTransform { perspective, view }
+                    let modelview_to_eye = Transform3DF::from(camera.transform).inverse().post_mul(initial_camera);
+                    OcularTransform { perspective, modelview_to_eye }
                 })
                 .collect();
             self.in_frame = true;
@@ -363,41 +356,41 @@ impl MLTransform {
 
 // Impl pathfinder traits for c-api types
 
-impl From<MLTransform> for Transform3DF32 {
+impl From<MLTransform> for Transform3DF {
     fn from(mat: MLTransform) -> Self {
-        Transform3DF32::from(mat.rotation)
-           .pre_mul(&Transform3DF32::from(mat.position))
+        Transform3DF::from(mat.rotation)
+           .pre_mul(&Transform3DF::from(mat.position))
     }
 }
 
-impl From<MLVec3f> for Transform3DF32 {
+impl From<MLVec3f> for Transform3DF {
     fn from(v: MLVec3f) -> Self {
-        Transform3DF32::from_translation(v.x, v.y, v.z)
+        Transform3DF::from_translation(v.x, v.y, v.z)
     }
 }
 
-impl From<MLRectf> for RectF32 {
+impl From<MLRectf> for RectF {
     fn from(r: MLRectf) -> Self {
-        RectF32::new(Point2DF32::new(r.x, r.y), Point2DF32::new(r.w, r.h))
+        RectF::new(Point2DF::new(r.x, r.y), Point2DF::new(r.w, r.h))
     }
 }
 
-impl From<MLRectf> for RectI32 {
+impl From<MLRectf> for RectI {
     fn from(r: MLRectf) -> Self {
-        RectF32::from(r).to_i32()
+        RectF::from(r).to_i32()
     }
 }
 
-impl From<MLQuaternionf> for Transform3DF32 {
+impl From<MLQuaternionf> for Transform3DF {
     fn from(q: MLQuaternionf) -> Self {
-        Transform3DF32::from_rotation_quaternion(F32x4::new(q.x, q.y, q.z, q.w))
+        Transform3DF::from_rotation_quaternion(F32x4::new(q.x, q.y, q.z, q.w))
     }
 }
 
-impl From<MLMat4f> for Transform3DF32 {
+impl From<MLMat4f> for Transform3DF {
     fn from(mat: MLMat4f) -> Self {
         let a = mat.matrix_colmajor;
-        Transform3DF32::row_major(a[0], a[4], a[8],  a[12],
+        Transform3DF::row_major(a[0], a[4], a[8],  a[12],
                                   a[1], a[5], a[9],  a[13],
                                   a[2], a[6], a[10], a[14],
                                   a[3], a[7], a[11], a[15])

--- a/demo/magicleap/src/magicleap.rs
+++ b/demo/magicleap/src/magicleap.rs
@@ -48,8 +48,8 @@ use pathfinder_demo::window::OcularTransform;
 use pathfinder_demo::window::View;
 use pathfinder_demo::window::Window;
 use pathfinder_demo::window::WindowSize;
-use pathfinder_geometry::basic::point::Point2DI;
-use pathfinder_geometry::basic::point::Point2DF;
+use pathfinder_geometry::basic::vector::Vector2I;
+use pathfinder_geometry::basic::vector::Vector2F;
 use pathfinder_geometry::basic::rect::RectF;
 use pathfinder_geometry::basic::rect::RectI;
 use pathfinder_geometry::basic::transform3d::Perspective;
@@ -75,7 +75,7 @@ use std::time::Duration;
 pub struct MagicLeapWindow {
     framebuffer_id: GLuint,
     graphics_client: MLHandle,
-    size: Point2DI,
+    size: Vector2I,
     virtual_camera_array: MLGraphicsVirtualCameraInfoArray,
     initial_camera_transform: Option<Transform3DF>,
     frame_handle: MLHandle,
@@ -117,7 +117,7 @@ impl Window for MagicLeapWindow {
     }
 
     fn viewport(&self, _view: View) -> RectI {
-        RectI::new(Point2DI::default(), self.size)
+        RectI::new(Vector2I::default(), self.size)
     }
 
     fn make_current(&mut self, view: View) {
@@ -184,7 +184,7 @@ impl MagicLeapWindow {
         MagicLeapWindow {
             framebuffer_id,
             graphics_client,
-            size: Point2DI::new(max_width, max_height),
+            size: Vector2I::new(max_width, max_height),
             frame_handle: ML_HANDLE_INVALID,
             virtual_camera_array,
             initial_camera_transform: None,
@@ -370,7 +370,7 @@ impl From<MLVec3f> for Transform3DF {
 
 impl From<MLRectf> for RectF {
     fn from(r: MLRectf) -> Self {
-        RectF::new(Point2DF::new(r.x, r.y), Point2DF::new(r.w, r.h))
+        RectF::new(Vector2F::new(r.x, r.y), Vector2F::new(r.w, r.h))
     }
 }
 

--- a/demo/magicleap/src/main.cpp
+++ b/demo/magicleap/src/main.cpp
@@ -228,7 +228,11 @@ int main() {
   }
 
   // Initialize pathfinder
+  ML_LOG(Info, "%s: Initializing demo.", application_name);
   void* app = magicleap_pathfinder_demo_init(graphics_context.egl_display, graphics_context.egl_context);
+  if (!app) {
+    ML_LOG(Error, "%s: Failed to initialize demo.", application_name);
+  }
 
   // let system know our app has started
   MLLifecycleCallbacks lifecycle_callbacks = {};


### PR DESCRIPTION
These are the changes needed to get the magicleap demo running again. There are some minor changes to the common demo, the main one is calling `make_current` for each eye during rendering, previously we were assuming the only difference between eyes was the viewport.