### PR TITLE
Mention PFCanvasCreate() consumes the font context

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -108,6 +108,7 @@ pub struct PFRenderOptions {
 
 // `canvas`
 
+/// Consumes the font context.
 #[no_mangle]
 pub unsafe extern "C" fn PFCanvasCreate(font_context: PFCanvasFontContextRef,
                                         size: *const PFVector2F)


### PR DESCRIPTION
As mentioned in #179, I thought mentioning that `PFCanvasCreate()` consumes the font context might help make its usage a bit clearer.