### PR TITLE
full build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ addons:
     - libegl1-mesa-dev
     - libgtk-3-dev
     - libsdl2-dev
+    - cmake
 script:
-  - cd demo/native
   - cargo build
-  - cd ../magicleap
-  - cargo build
+  # - cargo test # todo: fix tests


### PR DESCRIPTION
- add cmake via apt
- replace demo builds with root-level `cargo build`

`cargo test` works, too, but there are a couple failing tests so I commented it out.