### PR TITLE
Define ck() based on cfg(debug_assertions)

### DIFF
--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -918,7 +918,7 @@ impl GLVersion {
 
 // Error checking
 
-#[cfg(debug)]
+#[cfg(debug_assertions)]
 fn ck() {
     unsafe {
         let err = gl::GetError();
@@ -928,7 +928,7 @@ fn ck() {
     }
 }
 
-#[cfg(not(debug))]
+#[cfg(not(debug_assertions))]
 fn ck() {}
 
 // Shader preprocessing

--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -921,9 +921,20 @@ impl GLVersion {
 #[cfg(debug_assertions)]
 fn ck() {
     unsafe {
+        // Note that ideally we should be calling gl::GetError() in a loop until it
+        // returns gl::NO_ERROR, but for now we'll just report the first one we find.
         let err = gl::GetError();
-        if err != 0 {
-            panic!("GL error: 0x{:x}", err);
+        if err != gl::NO_ERROR {
+            panic!("GL error: 0x{:x} ({})", err, match err {
+                gl::INVALID_ENUM => "INVALID_ENUM",
+                gl::INVALID_VALUE => "INVALID_VALUE",
+                gl::INVALID_OPERATION => "INVALID_OPERATION",
+                gl::INVALID_FRAMEBUFFER_OPERATION => "INVALID_FRAMEBUFFER_OPERATION",
+                gl::OUT_OF_MEMORY => "OUT_OF_MEMORY",
+                gl::STACK_UNDERFLOW => "STACK_UNDERFLOW",
+                gl::STACK_OVERFLOW => "STACK_OVERFLOW",
+                _ => "Unknown"
+            });
         }
     }
 }


### PR DESCRIPTION
While attempting to investigate https://github.com/servo/pathfinder/issues/178, I noticed that the `ck()` function, which checks to see if there's a GL error and panics if so, wasn't running on my debug build.  Its definition was conditional based on whether `cfg(debug)` is set, but I'm not actually sure what that is or how to set it, whereas [`cfg(debug_assertions)` does the trick](https://stackoverflow.com/a/39205417/2422398).

This PR changes the conditional compilation to be based on `debug_assertions`.  However, if that's not the right way to approach this, please let me know!
