### PR TITLE
Assert vertex attr locations exist in GLDevice.

### DIFF
--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -305,18 +305,24 @@ impl Device for GLDevice {
     }
 
     fn get_vertex_attr(&self, program: &Self::Program, name: &str) -> GLVertexAttr {
-        let name = CString::new(format!("a{}", name)).unwrap();
-        let attr = unsafe {
-            gl::GetAttribLocation(program.gl_program, name.as_ptr() as *const GLchar) as GLuint
+        let cname = CString::new(format!("a{}", name)).unwrap();
+        let attr_int = unsafe {
+            gl::GetAttribLocation(program.gl_program, cname.as_ptr() as *const GLchar)
         }; ck();
-        GLVertexAttr { attr }
+        if attr_int == -1 {
+            panic!("Vertex attribute '{}' does not exist in program", name);
+        }
+        GLVertexAttr { attr: attr_int as GLuint }
     }
 
     fn get_uniform(&self, program: &GLProgram, name: &str) -> GLUniform {
-        let name = CString::new(format!("u{}", name)).unwrap();
+        let cname = CString::new(format!("u{}", name)).unwrap();
         let location = unsafe {
-            gl::GetUniformLocation(program.gl_program, name.as_ptr() as *const GLchar)
+            gl::GetUniformLocation(program.gl_program, cname.as_ptr() as *const GLchar)
         }; ck();
+        if location == -1 {
+            panic!("Uniform '{}' does not exist in program", name);
+        }
         GLUniform { location }
     }
 

--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -309,20 +309,15 @@ impl Device for GLDevice {
         let attr_int = unsafe {
             gl::GetAttribLocation(program.gl_program, cname.as_ptr() as *const GLchar)
         }; ck();
-        if attr_int == -1 {
-            panic!("Vertex attribute '{}' does not exist in program", name);
-        }
+        debug_assert!(attr_int != -1, "Vertex attribute '{}' does not exist in program", name);
         GLVertexAttr { attr: attr_int as GLuint }
     }
 
     fn get_uniform(&self, program: &GLProgram, name: &str) -> GLUniform {
-        let cname = CString::new(format!("u{}", name)).unwrap();
+        let name = CString::new(format!("u{}", name)).unwrap();
         let location = unsafe {
-            gl::GetUniformLocation(program.gl_program, cname.as_ptr() as *const GLchar)
+            gl::GetUniformLocation(program.gl_program, name.as_ptr() as *const GLchar)
         }; ck();
-        if location == -1 {
-            panic!("Uniform '{}' does not exist in program", name);
-        }
         GLUniform { location }
     }
 


### PR DESCRIPTION
As @benpye discovered in https://github.com/servo/pathfinder/issues/183#issuecomment-500097365, Pathfinder crashes on systems with Nvidia drivers at least in part because it's looking up locations for vertex attributes that don't exist in some shaders.  In the spirit of "crash early, crash often", this PR adds assertions that ensure the vertex attribute ~~and uniform locations~~ we return are valid in `GLDevice`.  This doesn't fix any problems, of course, it just makes it easier to be aware of their existence on non-Nvidia systems, and makes them easier to debug.

That said, I'm not sure if this actually the best solution: perhaps `Device::get_vertex_attr()` and `Device::get_uniform()` should actually return `Option`-wrapped values, so that code calling it can change its behavior based on whether the attributes/uniforms exist or not?  I guess I'm not familiar enough with Pathfinder's codebase to know the best answer.  Regardless, no worries if you decide not to merge this.