### PR TITLE
Fix Unity plugin crash and add debug assertions

### DIFF
--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -539,6 +539,7 @@ impl Device for GLDevice {
 
     fn draw_elements(&self, primitive: Primitive, index_count: u32, render_state: &RenderState) {
         self.set_render_state(render_state);
+        assert_element_array_buffer_is_bound();
         unsafe {
             gl::DrawElements(primitive.to_gl_primitive(),
                              index_count as GLsizei,
@@ -554,6 +555,7 @@ impl Device for GLDevice {
                                instance_count: u32,
                                render_state: &RenderState) {
         self.set_render_state(render_state);
+        assert_element_array_buffer_is_bound();
         unsafe {
             gl::DrawElementsInstanced(primitive.to_gl_primitive(),
                                       index_count as GLsizei,
@@ -904,6 +906,20 @@ impl GLVersion {
 }
 
 // Error checking
+
+#[cfg(debug_assertions)]
+fn assert_element_array_buffer_is_bound() {
+    unsafe {
+        let mut buffer: GLint = 0;
+        gl::GetIntegerv(gl::ELEMENT_ARRAY_BUFFER_BINDING, &mut buffer); ck();
+        if buffer == 0 {
+            panic!("No buffer object is bound to the target GL_ELEMENT_ARRAY_BUFFER!");
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn assert_element_array_buffer_is_bound() {}
 
 #[cfg(debug_assertions)]
 fn ck() {

--- a/renderer/src/gpu/renderer.rs
+++ b/renderer/src/gpu/renderer.rs
@@ -548,6 +548,7 @@ where
             stencil: self.stencil_state(),
             ..RenderState::default()
         };
+        self.device.bind_buffer(self.quad_vertex_indices_buffer(), BufferTarget::Index);
         self.device.draw_elements_instanced(Primitive::Triangles, 6, count, &render_state);
     }
 


### PR DESCRIPTION
Okay, I did some investigating into #178 and discovered a few things.

Right now, the Unity plugin instantiates a `Renderer` only once and reuses it every frame (instantiating one every frame seemed excessive, but I can alter this behavior if you want).  However, as of acf666b70161228f139b8cc9c4e03a75a5c1101c, the `quad_vertex_indices_buffer` is only bound to `GL_ELEMENT_ARRAY_BUFFER` when the renderer is instantiated--not every frame.

This seems fine if we assume that other GL code hasn't changed the binding since the renderer was instantiated.  I _think_ this is what's going on with the Unity plugin: because the plugin has to share the same GL context with Unity's own renderer, it's likely that Unity is changing the `GL_ELEMENT_ARRAY_BUFFER` binding when it's doing its own drawing.

Furthermore, the stack trace mentioned at https://github.com/servo/pathfinder/issues/178#issuecomment-498854709 is happening because [the `indices` parameter of `glDrawElementsInstanced()` is defined in a confusing way](https://stackoverflow.com/questions/21706113/the-4th-argument-in-gldrawelements-is-what): if `GL_ELEMENT_ARRAY_BUFFER` is bound, then it's interpreted as an offset index into an array (which is how we're using it), but if it's _not_ bound anymore--as is the case when running in Unity--it's interpreted as a pointer value, in which case the program will segfault.

I'm not really sure what the best solution is here.  I've added a debug assertion called `assert_element_array_buffer_is_bound()` to make us panic with a helpful error instead of causing a null pointer dereference, which will hopefully help us catch errors like this in the future, but I'm not sure what the best strategy to ensure the proper buffer binding is.  If we only plan to ever bind `quad_vertex_positions_buffer` to `GL_ELEMENT_ARRAY_BUFFER` then we could just bind it once during `Renderer::begin_scene()`, but otherwise we may need to bind it immediately before we call `glDrawElementsInstanced()` or anything else that needs it.

For now I've just done the minimal possible required to make the minimal canvas example work in the Unity plugin, but it's possible the ideal solution is something different.  I'm open to suggestions, this PR is really just my way of starting the conversation.
