### PR TITLE
SceneExt::push_layout make transform apply to offsets

### DIFF
--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -94,7 +94,7 @@ impl SceneExt for Scene {
             let scale = style.size / (font.metrics().units_per_em as f32);
             let scale = Vector2F::new(scale, -scale);
             let transform =
-                Transform2DF::from_scale(scale).post_mul(transform).post_translate(offset);
+                Transform2DF::from_scale(scale).post_translate(offset).post_mul(transform);
             self.push_glyph(font,
                             glyph.glyph_id,
                             &transform,


### PR DESCRIPTION
I think this should be the correct approach. At least it renders text properly with a transformation containing a scale component of != 1.

The Demo still renders properly and it fixes some funny glitches.