### PR TITLE
Expose Canvas transform and save/restore to C

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -321,6 +321,16 @@ pub unsafe extern "C" fn PFCanvasResetTransform(canvas: PFCanvasRef) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn PFCanvasSave(canvas: PFCanvasRef) {
+    (*canvas).save();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn PFCanvasRestore(canvas: PFCanvasRef) {
+    (*canvas).restore();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn PFCanvasSetLineDashOffset(canvas: PFCanvasRef, new_offset: f32) {
     (*canvas).set_line_dash_offset(new_offset)
 }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -311,6 +311,16 @@ pub unsafe extern "C" fn PFCanvasSetLineDash(canvas: PFCanvasRef,
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn PFCanvasSetCurrentTransform(canvas: PFCanvasRef, transform: *const PFTransform2F) {
+    (*canvas).set_current_transform(&(*transform).to_rust());
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn PFCanvasResetTransform(canvas: PFCanvasRef) {
+    (*canvas).reset_transform();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn PFCanvasSetLineDashOffset(canvas: PFCanvasRef, new_offset: f32) {
     (*canvas).set_line_dash_offset(new_offset)
 }


### PR DESCRIPTION
This exposes the Canvas' transform and save/restore functionality to the C API.

The only method I haven't added here is `Canvas::current_transform()`, which I can add for completeness if you want.
