### PR TITLE
Remove log restriction

### DIFF
--- a/demo/common/Cargo.toml
+++ b/demo/common/Cargo.toml
@@ -20,7 +20,6 @@ features = ["png_codec"]
 
 [dependencies.log]
 version = "0.4"
-features = ["release_max_level_warn"]
 
 [dependencies.pathfinder_content]
 path = "../../content"

--- a/geometry/Cargo.toml
+++ b/geometry/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://github.com/servo/pathfinder"
 
 [dependencies.log]
 version = "0.4"
-features = ["release_max_level_warn"]
 
 [dependencies.pathfinder_simd]
 path = "../simd"

--- a/gl/Cargo.toml
+++ b/gl/Cargo.toml
@@ -13,7 +13,6 @@ half = "1.4"
 
 [dependencies.log]
 version = "0.4"
-features = ["release_max_level_warn"]
 
 [dependencies.pathfinder_geometry]
 path = "../geometry"

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -15,7 +15,6 @@ smallvec = "0.6"
 
 [dependencies.log]
 version = "0.4"
-features = ["release_max_level_warn"]
 
 [dependencies.pathfinder_content]
 path = "../content"


### PR DESCRIPTION
pathfinder-geometry enabled a log feature that restricts logging to warn for any binary using it.

This is really hard to find for anyone using the package as suddenly logging seems to stop working for no apparent reason