### PR TITLE
Use instant crate to build for wasm32 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "pathfinder_geometry 0.4.0",
  "pathfinder_gpu 0.1.0",
  "pathfinder_renderer 0.1.0",
+ "pathfinder_resources 0.1.0",
  "pathfinder_simd 0.4.0",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1.0"
 serde_json = "1.0"
 smallvec = "1.2"
 vec_map = "0.8"
+instant = { version = "0.1.2", features = ["wasm-bindgen"] }
 
 [dependencies.log]
 version = "0.4"

--- a/renderer/src/builder.rs
+++ b/renderer/src/builder.rs
@@ -32,7 +32,7 @@ use pathfinder_geometry::vector::{Vector2F, Vector2I};
 use pathfinder_gpu::TextureSamplingFlags;
 use pathfinder_simd::default::{F32x4, I32x4};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
+use instant::Instant;
 use std::u16;
 
 pub(crate) struct SceneBuilder<'a> {

--- a/webgl/Cargo.toml
+++ b/webgl/Cargo.toml
@@ -42,3 +42,6 @@ features = [
   'WebGlVertexArrayObject',
   'Window',
 ]
+
+[dependencies.pathfinder_resources]
+path = "../resources"


### PR DESCRIPTION
This PR fixes several problems to make pathfinder fully available to wasm32. Including:
- Use `instant` crate instead of `std::time::Instant` to compile to wasm32 (only changed in wasm32 available subcrates)
- fix the `pathfinder_resources` dependency in webgl module