### PR TITLE
Add derive(Clone) to no text font context

### DIFF
--- a/canvas/src/text_no_text.rs
+++ b/canvas/src/text_no_text.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[derive(Clone)]
 pub struct CanvasFontContext;
 
 impl CanvasFontContext {


### PR DESCRIPTION
I think this should match the text version  to make it easier to swap between them.