### PR TITLE
Provide a placeholder definition of `CAMetalLayer` in the C API.

### DIFF
--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -12,6 +12,10 @@ header = """\
 #ifdef __cplusplus
 extern \"C\" {
 #endif
+
+#ifndef __APPLE__
+typedef struct CAMetalLayerPrivate CAMetalLayer;
+#endif
 """
 trailer = """\
 #ifdef __cplusplus


### PR DESCRIPTION
Closes #260.