### PR TITLE
Add missing Metal shader to resources/MANIFEST

### DIFF
--- a/resources/MANIFEST
+++ b/resources/MANIFEST
@@ -57,6 +57,7 @@ shaders/metal/debug_texture.fs.metal
 shaders/metal/debug_texture.vs.metal
 shaders/metal/demo_ground.fs.metal
 shaders/metal/demo_ground.vs.metal
+shaders/metal/fill.cs.metal
 shaders/metal/fill.fs.metal
 shaders/metal/fill.vs.metal
 shaders/metal/reproject.fs.metal


### PR DESCRIPTION
This fixes an issue that caused `pathfinder_metal` to panic when [attempting to load shaders](https://github.com/servo/pathfinder/blob/0f3500921596bdb2924d7bd62c4f983afc9332ec/metal/src/lib.rs#L854) using the embedded resource loader.

/cc: @nathansobo