### PR TITLE
Only use foreign-types on macOS in the C API

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -11,7 +11,6 @@
 //! C bindings to Pathfinder.
 
 use font_kit::handle::Handle;
-use foreign_types::ForeignTypeRef;
 use gl;
 use pathfinder_canvas::{Canvas, CanvasFontContext, CanvasRenderingContext2D, FillStyle, LineJoin};
 use pathfinder_canvas::{Path2D, TextAlign, TextMetrics};
@@ -42,6 +41,8 @@ use std::str;
 use metal::{CAMetalLayer, CoreAnimationLayerRef, Device};
 #[cfg(all(target_os = "macos", not(feature = "pf-gl")))]
 use pathfinder_metal::MetalDevice;
+#[cfg(all(target_os = "macos", not(feature = "pf-gl")))]
+use foreign_types::ForeignTypeRef;
 
 // Constants
 


### PR DESCRIPTION
Its only use is for `CoreAnimationLayerRef::from_ptr()` in `PFMetalDeviceCreate`, so this fixes a warning on other platforms.

The last time I tried to fix this warning I didn’t notice that it was actually used, and thus 2d2bc14e5cb597bc9c8f602d28c4a16902fd1938 broke the macOS build in #257.