### PR TITLE
Expose pathfinder_svg to the C API

### DIFF
--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -13,6 +13,7 @@ font-kit = "0.6"
 foreign-types = "0.3"
 gl = "0.14"
 libc = "0.2"
+usvg = "0.9"
 
 [dependencies.pathfinder_canvas]
 features = ["pf-text"]
@@ -41,6 +42,9 @@ path = "../resources"
 
 [dependencies.pathfinder_simd]
 path = "../simd"
+
+[dependencies.pathfinder_svg]
+path = "../svg"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.17"

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -35,10 +35,12 @@ include = [
     "pathfinder_gpu",
     "pathfinder_metal",
     "pathfinder_renderer",
+    "pathfinder_svg",
 ]
 
 [export.rename]
 "BuildOptions" = "PFBuildOptionsPrivate"
+"BuiltSVG" = "PFBuiltSVGPrivate"
 "CanvasFontContext" = "PFCanvasFontContextPrivate"
 "CanvasRenderingContext2D" = "PFCanvasRenderingContext2DPrivate"
 "DestFramebuffer_GLDevice" = "PFDestFramebufferGLDevicePrivate"


### PR DESCRIPTION
[usvg](https://crates.io/crates/usvg) doesn’t get exposed, so we can eventually replace this library without breaking the API.