### PR TITLE
Implement BitAnd, BitOr, and Not for U32x2 in scalar version.

### DIFF
--- a/simd/src/scalar/mod.rs
+++ b/simd/src/scalar/mod.rs
@@ -10,7 +10,7 @@
 
 use std::f32;
 use std::fmt::{self, Debug, Formatter};
-use std::ops::{Add, BitAnd, BitOr, Div, Index, IndexMut, Mul, Shr, Sub};
+use std::ops::{Add, BitAnd, BitOr, Div, Index, IndexMut, Mul, Shr, Sub, Not};
 
 mod swizzle_f32x4;
 mod swizzle_i32x4;
@@ -839,6 +839,31 @@ impl U32x2 {
     #[inline]
     pub fn to_i32x2(self) -> I32x2 {
         I32x2::new(self[0] as i32, self[1] as i32)
+    }
+
+}
+
+impl BitAnd<U32x2> for U32x2 {
+    type Output = U32x2;
+    #[inline]
+    fn bitand(self, other: U32x2) -> U32x2 {
+        U32x2([self[0] & other[0], self[1] & other[1]])
+    }
+}
+
+impl BitOr<U32x2> for U32x2 {
+    type Output = U32x2;
+    #[inline]
+    fn bitor(self, other: U32x2) -> U32x2 {
+        U32x2([self[0] | other[0], self[1] | other[1]])
+    }
+}
+
+impl Not for U32x2 {
+    type Output = U32x2;
+    #[inline]
+    fn not(self) -> U32x2 {
+        U32x2([!self[0], !self[1]])
     }
 }
 


### PR DESCRIPTION
These were added to the other simd implementations, but left out of the scalar implementation, leading to build errors when using feature "pf-no-simd" (or building on a platform without hardware simd).