### PR TITLE
Expose EmbeddedResourceLoader to c api

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -508,7 +508,8 @@ pub unsafe extern "C" fn PFFillStyleDestroy(fill_style: PFFillStyleRef) {
     drop(Box::from_raw(fill_style))
 }
 
-// `gl`
+// `resources`
+
 #[no_mangle]
 pub unsafe extern "C" fn PFEmbeddedResourceLoaderCreate() -> PFResourceLoaderRef {
     let loader = Box::new(EmbeddedResourceLoader::new());
@@ -528,6 +529,9 @@ pub unsafe extern "C" fn PFFilesystemResourceLoaderFromPath(path: *const c_char)
     let loader = Box::new(FilesystemResourceLoader { directory });
     Box::into_raw(Box::new(ResourceLoaderWrapper(loader as Box<dyn ResourceLoader>)))
 }
+
+
+// `gl`
 
 #[no_mangle]
 pub unsafe extern "C" fn PFGLLoadWith(loader: PFGLFunctionLoader, userdata: *mut c_void) {

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -26,6 +26,7 @@ use pathfinder_gl::{GLDevice, GLVersion};
 use pathfinder_gpu::Device;
 use pathfinder_resources::ResourceLoader;
 use pathfinder_resources::fs::FilesystemResourceLoader;
+use pathfinder_resources::embedded::EmbeddedResourceLoader;
 use pathfinder_renderer::concurrent::rayon::RayonExecutor;
 use pathfinder_renderer::concurrent::scene_proxy::SceneProxy;
 use pathfinder_renderer::gpu::options::{DestFramebuffer, RendererLevel};
@@ -508,6 +509,11 @@ pub unsafe extern "C" fn PFFillStyleDestroy(fill_style: PFFillStyleRef) {
 }
 
 // `gl`
+#[no_mangle]
+pub unsafe extern "C" fn PFEmbeddedResourceLoaderCreate() -> PFResourceLoaderRef {
+    let loader = Box::new(EmbeddedResourceLoader::new());
+    Box::into_raw(Box::new(ResourceLoaderWrapper(loader as Box<dyn ResourceLoader>)))
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn PFFilesystemResourceLoaderLocate() -> PFResourceLoaderRef {

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -530,6 +530,10 @@ pub unsafe extern "C" fn PFFilesystemResourceLoaderFromPath(path: *const c_char)
     Box::into_raw(Box::new(ResourceLoaderWrapper(loader as Box<dyn ResourceLoader>)))
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn PFResourceLoaderDestroy(loader: PFResourceLoaderRef) {
+    drop(Box::from_raw(loader))
+}
 
 // `gl`
 
@@ -556,11 +560,6 @@ pub unsafe extern "C" fn PFGLDeviceCreate(version: PFGLVersion, default_framebuf
 #[no_mangle]
 pub unsafe extern "C" fn PFGLDeviceDestroy(device: PFGLDeviceRef) {
     drop(Box::from_raw(device))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn PFResourceLoaderDestroy(loader: PFResourceLoaderRef) {
-    drop(Box::from_raw(loader))
 }
 
 // `gpu`


### PR DESCRIPTION
### Background
This PR exposes the c api to the EmbeddedResourceLoader, to prevent some of the issues mentioned [here](https://github.com/servo/pathfinder/issues/234). 

### Approach
- Followed `PFFilesystemResourceLoaderLocate` and simply exposed the ERL's new and boxed it in the ResourceLoaderWrapper
- Used the `Create` terminology in the signature to match the rest of the api where a new() is called

### Notes
- I successfully tested it in a little .NET binding project I'm working on.
- Moved the \`gl\` section comment down with the GL methods, as it seemed a little out of place. added a \`resources\` one. then moved the destroy fn in to the new section.

Let me know if I misinterpreted anything or if there are any changes, stylistic or otherwise, that you'd prefer. Thanks!