### PR TITLE
Fix Metal memory management and the `canvas_metal_minimal`, `canvas_nanovg`, and `macos_app` examples.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ version = "0.1.0"
 dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathfinder_canvas 0.5.0",
  "pathfinder_color 0.5.0",
@@ -414,6 +414,20 @@ dependencies = [
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,7 +672,7 @@ dependencies = [
  "io-surface 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nfd 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathfinder_demo 0.1.0",
@@ -1429,6 +1443,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,11 +1711,13 @@ name = "pathfinder_c"
 version = "0.1.0"
 dependencies = [
  "cbindgen 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-kit 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathfinder_canvas 0.5.0",
  "pathfinder_color 0.5.0",
  "pathfinder_content 0.5.0",
@@ -1746,7 +1776,7 @@ dependencies = [
  "image 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-surface 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathfinder_color 0.5.0",
  "pathfinder_content 0.5.0",
  "pathfinder_export 0.1.0",
@@ -1856,7 +1886,7 @@ dependencies = [
  "half 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-surface 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathfinder_geometry 0.5.1",
  "pathfinder_gpu 0.5.0",
@@ -3096,6 +3126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum cocoa 0.18.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1706996401131526e36b3b49f0c4d912639ce110996f3ca144d78946727bce54"
 "checksum cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f29f7768b2d1be17b96158e3285951d366b40211320fb30826a76cb7a0da6400"
+"checksum cocoa 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c49e86fc36d5704151f5996b7b3795385f50ce09e3be0f47a0cfde869681cf8"
 "checksum color-backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "65d13f1078cc63c791d0deba0dd43db37c9ec02b311f10bed10b577016f3a957"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
@@ -3207,6 +3238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memmap2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b70ca2a6103ac8b665dc150b142ef0e4e89df640c9e6cf295d189c3caebe5a"
 "checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum metal 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f83c7dcc2038e12f68493fa3de44235df27b2497178e257185b4b5b5d028a1e4"
+"checksum metal 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e198a0ee42bdbe9ef2c09d0b9426f3b2b47d90d93a4a9b0395c4cea605e92dc0"
 "checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -46,7 +46,9 @@ path = "../simd"
 path = "../svg"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.17"
+core-foundation = "0.6"
+io-surface = "0.12"
+metal = "0.18"
 
 [target.'cfg(target_os = "macos")'.dependencies.pathfinder_metal]
 path = "../metal"

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -35,18 +35,21 @@ include = [
     "pathfinder_gpu",
     "pathfinder_metal",
     "pathfinder_renderer",
+    "pathfinder_svg",
 ]
 
 [export.rename]
 "BuildOptions" = "PFBuildOptionsPrivate"
 "CanvasFontContext" = "PFCanvasFontContextPrivate"
 "CanvasRenderingContext2D" = "PFCanvasRenderingContext2DPrivate"
+"CoreAnimationDrawableRef" = "NSObject<CAMetalDrawable>"
 "DestFramebuffer_GLDevice" = "PFDestFramebufferGLDevicePrivate"
 "DestFramebuffer_MetalDevice" = "PFDestFramebufferMetalDevicePrivate"
 "FillStyle" = "PFFillStylePrivate"
 "GLDevice" = "PFGLDevicePrivate"
 "Handle" = "FKHandlePrivate"
 "MetalDevice" = "PFMetalDevicePrivate"
+"NativeMetalDeviceRef" = "NSObject<MTLDevice>"
 "Path2D" = "PFPath2DPrivate"
 "RenderTransform" = "PFRenderTransformPrivate"
 "Renderer_GLDevice" = "PFRendererGLDevicePrivate"
@@ -54,3 +57,4 @@ include = [
 "ResourceLoaderWrapper" = "PFResourceLoaderWrapperPrivate"
 "Scene" = "PFScenePrivate"
 "SceneProxy" = "PFSceneProxyPrivate"
+"SVGScene" = "PFSVGScenePrivate"

--- a/demo/common/Cargo.toml
+++ b/demo/common/Cargo.toml
@@ -55,7 +55,7 @@ path = "../../svg"
 path = "../../ui"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.17"
+metal = "0.18"
 
 [target.'cfg(target_os = "macos")'.dependencies.io-surface]
 version = "0.12"

--- a/demo/native/Cargo.toml
+++ b/demo/native/Cargo.toml
@@ -48,7 +48,7 @@ version = "<0.19.4" # 0.19.4 causes build errors https://github.com/rust-windowi
 [target.'cfg(target_os = "macos")'.dependencies]
 foreign-types = "0.3"
 io-surface = "0.12"
-metal = "0.17"
+metal = "0.18"
 objc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies.pathfinder_metal]

--- a/demo/native/src/main.rs
+++ b/demo/native/src/main.rs
@@ -26,6 +26,7 @@ use pathfinder_resources::ResourceLoader;
 use pathfinder_resources::fs::FilesystemResourceLoader;
 use std::cell::Cell;
 use std::collections::VecDeque;
+use std::mem;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use surfman::{SurfaceAccess, SurfaceType, declare_surfman};
@@ -160,7 +161,10 @@ impl Window for WindowImpl {
 
     #[cfg(all(target_os = "macos", not(feature = "pf-gl")))]
     fn metal_device(&self) -> metal::Device {
-        self.metal_device.0.clone()
+        // FIXME(pcwalton): Remove once `surfman` upgrades `metal-rs` version.
+        unsafe {
+            mem::transmute(self.metal_device.0.clone())
+        }
     }
 
     #[cfg(all(target_os = "macos", not(feature = "pf-gl")))]

--- a/examples/canvas_metal_minimal/Cargo.toml
+++ b/examples/canvas_metal_minimal/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 foreign-types = "0.3"
 gl = "0.14"
-metal = "0.17"
+metal = "0.18"
 objc = "0.2"
 sdl2 = "0.33"
 sdl2-sys = "0.33"

--- a/examples/canvas_metal_minimal/src/main.rs
+++ b/examples/canvas_metal_minimal/src/main.rs
@@ -44,9 +44,13 @@ fn main() {
     let metal_layer = unsafe {
         CoreAnimationLayerRef::from_ptr(SDL_RenderGetMetalLayer(canvas.raw()) as *mut CAMetalLayer)
     };
+    let metal_device = metal_layer.device();
+    let drawable = metal_layer.next_drawable().unwrap();
 
     // Create a Pathfinder renderer.
-    let device = MetalDevice::new(metal_layer);
+    let device = unsafe {
+        MetalDevice::new(metal_device, drawable.clone())
+    };
     let mode = RendererMode::default_for_device(&device);
     let options = RendererOptions {
         dest: DestFramebuffer::full_window(window_size),
@@ -81,7 +85,7 @@ fn main() {
                                            renderer.mode().level,
                                            RayonExecutor);
     scene.build_and_render(&mut renderer, BuildOptions::default());
-    renderer.device().present_drawable();
+    renderer.device().present_drawable(drawable);
 
     // Wait for a keypress.
     let mut event_pump = sdl_context.event_pump().unwrap();

--- a/examples/canvas_nanovg/src/main.rs
+++ b/examples/canvas_nanovg/src/main.rs
@@ -30,7 +30,7 @@ use pathfinder_geometry::vector::{Vector2F, vec2f, vec2i};
 use pathfinder_gl::{GLDevice, GLVersion};
 use pathfinder_renderer::concurrent::rayon::RayonExecutor;
 use pathfinder_renderer::concurrent::scene_proxy::SceneProxy;
-use pathfinder_renderer::gpu::options::{DestFramebuffer, RendererOptions};
+use pathfinder_renderer::gpu::options::{DestFramebuffer, RendererMode, RendererOptions};
 use pathfinder_renderer::gpu::renderer::Renderer;
 use pathfinder_renderer::options::BuildOptions;
 use pathfinder_resources::ResourceLoader;
@@ -1517,13 +1517,15 @@ fn main() {
     let pathfinder_device = GLDevice::new(GLVersion::GL3, default_framebuffer);
 
     // Create a Pathfinder renderer.
+    let renderer_mode = RendererMode::default_for_device(&pathfinder_device);
     let renderer_options = RendererOptions {
         background_color: Some(rgbf(0.3, 0.3, 0.32)),
-        ..RendererOptions::default_for_device(&pathfinder_device)
+        dest: DestFramebuffer::full_window(framebuffer_size),
+        ..RendererOptions::default()
     };
     let mut renderer = Renderer::new(pathfinder_device,
                                      &resources,
-                                     DestFramebuffer::full_window(framebuffer_size),
+                                     renderer_mode,
                                      renderer_options);
 
     // Initialize font state.
@@ -1568,7 +1570,7 @@ fn main() {
         // Render the canvas to screen.
         let canvas = context.into_canvas();
         let mut scene = SceneProxy::from_scene(canvas.into_scene(),
-                                               renderer.level(),
+                                               renderer.mode().level,
                                                RayonExecutor);
         scene.build_and_render(&mut renderer, BuildOptions::default());
 

--- a/examples/macos_app/Pathfinder Example.xcodeproj/project.pbxproj
+++ b/examples/macos_app/Pathfinder Example.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6A9A35B322C1E14700B86652 /* libpathfinder_c.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A9A35B222C1E14700B86652 /* libpathfinder_c.a */; };
+		6A7C3B7224A6B75500027B8E /* libpathfinder_c.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A7C3B7124A6B75500027B8E /* libpathfinder_c.a */; };
 		6AFD6FFA22BD780D00AC1ED3 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6AFD6FF922BD780D00AC1ED3 /* AppDelegate.m */; };
 		6AFD6FFC22BD781000AC1ED3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6AFD6FFB22BD781000AC1ED3 /* Assets.xcassets */; };
 		6AFD6FFF22BD781000AC1ED3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6AFD6FFD22BD781000AC1ED3 /* MainMenu.xib */; };
@@ -17,7 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		6A9A35B222C1E14700B86652 /* libpathfinder_c.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpathfinder_c.a; path = ../../../target/release/libpathfinder_c.a; sourceTree = "<group>"; };
+		6A7C3B7124A6B75500027B8E /* libpathfinder_c.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpathfinder_c.a; path = ../../../target/release/libpathfinder_c.a; sourceTree = "<group>"; };
 		6AFD6FF522BD780D00AC1ED3 /* Pathfinder Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pathfinder Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AFD6FF822BD780D00AC1ED3 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		6AFD6FF922BD780D00AC1ED3 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -36,7 +36,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A9A35B322C1E14700B86652 /* libpathfinder_c.a in Frameworks */,
+				6A7C3B7224A6B75500027B8E /* libpathfinder_c.a in Frameworks */,
 				6AFD700F22BD930500AC1ED3 /* libharfbuzz.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -72,7 +72,7 @@
 				6AFD700A22BD7B7A00AC1ED3 /* PathfinderView.m */,
 				6AFD700122BD781000AC1ED3 /* main.m */,
 				6AFD700322BD781000AC1ED3 /* Pathfinder_Example.entitlements */,
-				6A9A35B222C1E14700B86652 /* libpathfinder_c.a */,
+				6A7C3B7124A6B75500027B8E /* libpathfinder_c.a */,
 				6AFD700E22BD930500AC1ED3 /* libharfbuzz.a */,
 			);
 			path = "Pathfinder Example";
@@ -290,7 +290,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = ../../c/build/include;
+				HEADER_SEARCH_PATHS = ../../target/release;
 				INFOPLIST_FILE = "Pathfinder Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -312,7 +312,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = ../../c/build/include;
+				HEADER_SEARCH_PATHS = ../../target/release;
 				INFOPLIST_FILE = "Pathfinder Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/examples/macos_app/Pathfinder Example.xcodeproj/xcshareddata/xcschemes/Pathfinder Example.xcscheme
+++ b/examples/macos_app/Pathfinder Example.xcodeproj/xcshareddata/xcschemes/Pathfinder Example.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Pathfinder Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -66,11 +64,6 @@
          <AdditionalOption
             key = "NSZombieEnabled"
             value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "MallocScribble"
-            value = ""
             isEnabled = "YES">
          </AdditionalOption>
       </AdditionalOptions>

--- a/examples/macos_app/Pathfinder Example.xcodeproj/xcuserdata/pcwalton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/examples/macos_app/Pathfinder Example.xcodeproj/xcuserdata/pcwalton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Bucket
+   uuid = "27BE8A7F-8037-481A-BC1B-F4E2EB192E10"
    type = "1"
    version = "2.0">
    <Breakpoints>
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.ExceptionBreakpoint">
          <BreakpointContent
+            uuid = "89D117F0-23EF-4726-A92E-2DCFF6C8E9B6"
             shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"

--- a/examples/macos_app/Pathfinder Example/PathfinderView.h
+++ b/examples/macos_app/Pathfinder Example/PathfinderView.h
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import <Metal/Metal.h>
-#include <pathfinder/pathfinder.h>
+#include <pathfinder_c.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,8 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
     PFBuildOptionsRef mBuildOptions;
     CVDisplayLinkRef mDisplayLink;
     int32_t mFrameNumber;
+    CAMetalLayer *mLayer;
     CGSize mLayerSize;
     NSLock *mRenderLock;
+    id<CAMetalDrawable> mCurrentDrawable;
 }
 
 - (void)_render;

--- a/metal/Cargo.toml
+++ b/metal/Cargo.toml
@@ -19,7 +19,7 @@ foreign-types = "0.3"
 half = "1.5"
 io-surface = "0.12"
 libc = "0.2"
-metal = "0.17"
+metal = "0.18"
 objc = "0.2"
 
 [dependencies.pathfinder_geometry]

--- a/renderer/src/gpu/d3d11/renderer.rs
+++ b/renderer/src/gpu/d3d11/renderer.rs
@@ -586,14 +586,24 @@ impl<D> RendererD3D11<D> where D: Device {
             (&propagate_program.alpha_tiles_storage_buffer, alpha_tiles_storage_buffer),
         ];
 
-        if let Some(clip_buffer_ids) = clip_buffer_ids {
-            let clip_metadata_buffer_id =
-                clip_buffer_ids.metadata.expect("Where's the clip metadata storage?");
-            let clip_metadata_buffer = core.allocator.get_buffer(clip_metadata_buffer_id);
-            let clip_tile_buffer = core.allocator.get_buffer(clip_buffer_ids.tiles);
-            storage_buffers.push((&propagate_program.clip_metadata_storage_buffer,
-                                  clip_metadata_buffer));
-            storage_buffers.push((&propagate_program.clip_tiles_storage_buffer, clip_tile_buffer));
+        match clip_buffer_ids {
+            Some(clip_buffer_ids) => {
+                let clip_metadata_buffer_id =
+                    clip_buffer_ids.metadata.expect("Where's the clip metadata storage?");
+                let clip_metadata_buffer = core.allocator.get_buffer(clip_metadata_buffer_id);
+                let clip_tile_buffer = core.allocator.get_buffer(clip_buffer_ids.tiles);
+                storage_buffers.push((&propagate_program.clip_metadata_storage_buffer,
+                                    clip_metadata_buffer));
+                storage_buffers.push((&propagate_program.clip_tiles_storage_buffer,
+                                      clip_tile_buffer));
+            }
+            None => {
+                // Just attach any old buffers to these, to satisfy Metal.
+                storage_buffers.push((&propagate_program.clip_metadata_storage_buffer,
+                                      propagate_metadata_storage_buffer));
+                storage_buffers.push((&propagate_program.clip_tiles_storage_buffer,
+                                      tiles_d3d11_buffer));
+            }
         }
 
         let timer_query = core.timer_query_cache.start_timing_draw_call(&core.device,

--- a/renderer/src/gpu/d3d9/renderer.rs
+++ b/renderer/src/gpu/d3d9/renderer.rs
@@ -425,11 +425,8 @@ impl<D> RendererD3D9<D> where D: Device {
 
         uniforms.push((&tile_raster_program.transform_uniform,
                        UniformData::Mat4(self.tile_transform(core).to_columns())));
-
-        if needs_readable_framebuffer {
-            textures.push((&tile_raster_program.dest_texture,
-                           core.device.framebuffer_texture(dest_blend_framebuffer)));
-        }
+        textures.push((&tile_raster_program.dest_texture,
+                        core.device.framebuffer_texture(dest_blend_framebuffer)));
 
         let z_buffer_texture = core.allocator.get_texture(z_buffer_texture_id);
         textures.push((&tile_raster_program.common.z_buffer_texture, z_buffer_texture));

--- a/renderer/src/gpu/renderer.rs
+++ b/renderer/src/gpu/renderer.rs
@@ -1010,6 +1010,8 @@ impl<D> RendererCore<D> where D: Device {
                                UniformData::Vec2(color_texture_size.0)));
             }
             None => {
+                // Attach any old texture, just to satisfy Metal.
+                textures.push((&tile_program.color_texture_0, texture_metadata_texture));
                 uniforms.push((&tile_program.color_texture_size_0_uniform,
                                UniformData::Vec2(F32x2::default())));
             }

--- a/resources/shaders/gl4/d3d11/tile.cs.glsl
+++ b/resources/shaders/gl4/d3d11/tile.cs.glsl
@@ -673,7 +673,6 @@ uniform sampler2D uZBuffer;
 uniform ivec2 uZBufferSize;
 uniform sampler2D uColorTexture0;
 uniform sampler2D uMaskTexture0;
-uniform sampler2D uDestTexture;
 uniform sampler2D uGammaLUT;
 uniform vec2 uColorTextureSize0;
 uniform vec2 uMaskTextureSize0;
@@ -762,10 +761,13 @@ void main(){
                                 filterParams2,
                                 ctrl);
 
+
+
+
             vec4 srcColor = calculateColor(fragCoord,
                                            uColorTexture0,
                                            uMaskTexture0,
-                                           uDestTexture,
+                                           uColorTexture0,
                                            uGammaLUT,
                                            uColorTextureSize0,
                                            uMaskTextureSize0,

--- a/resources/shaders/metal/d3d11/tile.cs.metal
+++ b/resources/shaders/metal/d3d11/tile.cs.metal
@@ -647,7 +647,7 @@ float4 calculateColor(thread const float2& fragCoord, thread const texture2d<flo
     return color;
 }
 
-kernel void main0(constant int2& uFramebufferTileSize [[buffer(3)]], constant int& uLoadAction [[buffer(4)]], constant int2& uTextureMetadataSize [[buffer(7)]], constant float2& uFramebufferSize [[buffer(0)]], constant float2& uTileSize [[buffer(1)]], constant float4& uClearColor [[buffer(5)]], constant float2& uColorTextureSize0 [[buffer(8)]], constant float2& uMaskTextureSize0 [[buffer(9)]], const device bFirstTileMap& _1510 [[buffer(2)]], const device bTiles& _1603 [[buffer(6)]], texture2d<float, access::read_write> uDestImage [[texture(0)]], texture2d<float> uTextureMetadata [[texture(1)]], texture2d<float> uColorTexture0 [[texture(2)]], texture2d<float> uMaskTexture0 [[texture(3)]], texture2d<float> uDestTexture [[texture(4)]], texture2d<float> uGammaLUT [[texture(5)]], sampler uTextureMetadataSmplr [[sampler(0)]], sampler uColorTexture0Smplr [[sampler(1)]], sampler uMaskTexture0Smplr [[sampler(2)]], sampler uDestTextureSmplr [[sampler(3)]], sampler uGammaLUTSmplr [[sampler(4)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]])
+kernel void main0(constant int2& uFramebufferTileSize [[buffer(3)]], constant int& uLoadAction [[buffer(4)]], constant int2& uTextureMetadataSize [[buffer(7)]], constant float2& uFramebufferSize [[buffer(0)]], constant float2& uTileSize [[buffer(1)]], constant float4& uClearColor [[buffer(5)]], constant float2& uColorTextureSize0 [[buffer(8)]], constant float2& uMaskTextureSize0 [[buffer(9)]], const device bFirstTileMap& _1510 [[buffer(2)]], const device bTiles& _1603 [[buffer(6)]], texture2d<float, access::read_write> uDestImage [[texture(0)]], texture2d<float> uTextureMetadata [[texture(1)]], texture2d<float> uColorTexture0 [[texture(2)]], texture2d<float> uMaskTexture0 [[texture(3)]], texture2d<float> uGammaLUT [[texture(4)]], sampler uTextureMetadataSmplr [[sampler(0)]], sampler uColorTexture0Smplr [[sampler(1)]], sampler uMaskTexture0Smplr [[sampler(2)]], sampler uGammaLUTSmplr [[sampler(3)]], uint3 gl_WorkGroupID [[threadgroup_position_in_grid]], uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]])
 {
     int2 tileCoord = int2(gl_WorkGroupID.xy);
     int2 firstTileSubCoord = int2(gl_LocalInvocationID.xy) * int2(1, 4);
@@ -723,7 +723,7 @@ kernel void main0(constant int2& uFramebufferTileSize [[buffer(3)]], constant in
             float2 param_19 = colorTexCoord0;
             float4 param_20 = baseColor;
             int param_21 = tileCtrl;
-            float4 srcColor = calculateColor(param_10, uColorTexture0, uColorTexture0Smplr, uMaskTexture0, uMaskTexture0Smplr, uDestTexture, uDestTextureSmplr, uGammaLUT, uGammaLUTSmplr, param_11, param_12, param_13, param_14, param_15, param_16, param_17, param_18, param_19, param_20, param_21);
+            float4 srcColor = calculateColor(param_10, uColorTexture0, uColorTexture0Smplr, uMaskTexture0, uMaskTexture0Smplr, uColorTexture0, uColorTexture0Smplr, uGammaLUT, uGammaLUTSmplr, param_11, param_12, param_13, param_14, param_15, param_16, param_17, param_18, param_19, param_20, param_21);
             destColors[subY_1] = (destColors[subY_1] * (1.0 - srcColor.w)) + srcColor;
         }
         tileIndex = int(_1603.iTiles[(tileIndex * 4) + 0]);

--- a/shaders/d3d11/tile.cs.glsl
+++ b/shaders/d3d11/tile.cs.glsl
@@ -40,7 +40,6 @@ uniform sampler2D uZBuffer;
 uniform ivec2 uZBufferSize;
 uniform sampler2D uColorTexture0;
 uniform sampler2D uMaskTexture0;
-uniform sampler2D uDestTexture;
 uniform sampler2D uGammaLUT;
 uniform vec2 uColorTextureSize0;
 uniform vec2 uMaskTextureSize0;
@@ -129,10 +128,13 @@ void main() {
                                 filterParams2,
                                 ctrl);
 
+            // FIXME(pcwalton): The `uColorTexture0` below is a placeholder and needs to be
+            // replaced!
+
             vec4 srcColor = calculateColor(fragCoord,
                                            uColorTexture0,
                                            uMaskTexture0,
-                                           uDestTexture,
+                                           uColorTexture0,
                                            uGammaLUT,
                                            uColorTextureSize0,
                                            uMaskTextureSize0,


### PR DESCRIPTION
`winit` does not create an autorelease pool, so the Metal backend had not taken
the presence of one into account. Now the Metal backend creates and flushes
autorelease pools as necessary.

Closes #334.
Closes #376.