### PR TITLE
Implement nested SVG clip paths in the D3D11 backend.

### DIFF
--- a/renderer/src/gpu_data.rs
+++ b/renderer/src/gpu_data.rs
@@ -179,8 +179,6 @@ pub struct SegmentIndicesD3D11 {
 #[derive(Clone, Debug)]
 pub struct ClippedPathInfo {
     /// The ID of the batch containing the clips.
-    /// 
-    /// In the current implementation, this is always 0.
     pub clip_batch_id: TileBatchId,
 
     /// The number of paths that have clips.
@@ -204,6 +202,12 @@ pub struct PathBatchIndex(pub u32);
 /// Unique ID that identifies a batch of tiles.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct TileBatchId(pub u32);
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct GlobalPathId {
+    pub batch_id: TileBatchId,
+    pub path_index: PathBatchIndex,
+}
 
 #[derive(Clone, Debug)]
 pub enum DrawTileBatch {
@@ -430,6 +434,13 @@ impl PathBatchIndex {
     #[inline]
     pub fn none() -> PathBatchIndex {
         PathBatchIndex(!0)
+    }
+}
+
+impl GlobalPathId {
+    #[inline]
+    pub fn none() -> GlobalPathId {
+        GlobalPathId { batch_id: TileBatchId(!0), path_index: PathBatchIndex(!0) }
     }
 }
 

--- a/renderer/src/scene.rs
+++ b/renderer/src/scene.rs
@@ -352,6 +352,7 @@ pub struct DrawPath {
 #[derive(Clone, Debug)]
 pub struct ClipPath {
     pub outline: Outline,
+    pub clip_path: Option<ClipPathId>,
     pub fill_rule: FillRule,
     pub name: String,
 }
@@ -447,12 +448,22 @@ impl DrawPath {
 impl ClipPath {
     #[inline]
     pub fn new(outline: Outline) -> ClipPath {
-        ClipPath { outline, fill_rule: FillRule::Winding, name: String::new() }
+        ClipPath { outline, clip_path: None, fill_rule: FillRule::Winding, name: String::new() }
     }
 
     #[inline]
     pub fn outline(&self) -> &Outline {
         &self.outline
+    }
+
+    #[inline]
+    pub(crate) fn clip_path(&self) -> Option<ClipPathId> {
+        self.clip_path
+    }
+
+    #[inline]
+    pub fn set_clip_path(&mut self, new_clip_path: Option<ClipPathId>) {
+        self.clip_path = new_clip_path
     }
 
     #[inline]

--- a/renderer/src/tiles.rs
+++ b/renderer/src/tiles.rs
@@ -31,7 +31,6 @@ pub(crate) struct DrawTilingPathInfo {
     pub(crate) paint_id: PaintId,
     pub(crate) blend_mode: BlendMode,
     pub(crate) fill_rule: FillRule,
-    pub(crate) clip_path_id: Option<ClipPathId>,
 }
 
 impl TilingPathInfo {

--- a/resources/shaders/gl4/d3d11/propagate.cs.glsl
+++ b/resources/shaders/gl4/d3d11/propagate.cs.glsl
@@ -150,11 +150,6 @@ void main(){
                                                         clipTileRect,
                                                         clipTileCoord);
 
-
-
-
-
-
                 int thisClipAlphaTileIndex =
                     int(iClipTiles[clipTileIndex * 4 +
                                                                    2]<< 8)>> 8;
@@ -186,8 +181,6 @@ void main(){
 
                         drawTileBackdrop = 0;
                         needNewAlphaTile = false;
-                    } else {
-                        needNewAlphaTile = true;
                     }
                 }
             } else {

--- a/resources/shaders/metal/d3d11/propagate.cs.metal
+++ b/resources/shaders/metal/d3d11/propagate.cs.metal
@@ -61,7 +61,7 @@ uint calculateTileIndex(thread const uint& bufferOffset, thread const uint4& til
     return (bufferOffset + (tileCoord.y * (tileRect.z - tileRect.x))) + tileCoord.x;
 }
 
-kernel void main0(constant int& uColumnCount [[buffer(0)]], constant int& uFirstAlphaTileIndex [[buffer(8)]], constant int2& uFramebufferTileSize [[buffer(9)]], const device bBackdrops& _59 [[buffer(1)]], const device bDrawMetadata& _85 [[buffer(2)]], const device bClipMetadata& _126 [[buffer(3)]], device bDrawTiles& _175 [[buffer(4)]], device bClipTiles& _252 [[buffer(5)]], device bIndirectDrawParams& _303 [[buffer(6)]], device bAlphaTiles& _310 [[buffer(7)]], device bZBuffer& _381 [[buffer(10)]], device bFirstTileMap& _398 [[buffer(11)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
+kernel void main0(constant int& uColumnCount [[buffer(0)]], constant int& uFirstAlphaTileIndex [[buffer(8)]], constant int2& uFramebufferTileSize [[buffer(9)]], const device bBackdrops& _59 [[buffer(1)]], const device bDrawMetadata& _85 [[buffer(2)]], const device bClipMetadata& _126 [[buffer(3)]], device bDrawTiles& _175 [[buffer(4)]], device bClipTiles& _252 [[buffer(5)]], device bIndirectDrawParams& _302 [[buffer(6)]], device bAlphaTiles& _309 [[buffer(7)]], device bZBuffer& _380 [[buffer(10)]], device bFirstTileMap& _397 [[buffer(11)]], uint3 gl_GlobalInvocationID [[thread_position_in_grid]])
 {
     uint columnIndex = gl_GlobalInvocationID.x;
     if (int(columnIndex) >= uColumnCount)
@@ -144,10 +144,6 @@ kernel void main0(constant int& uColumnCount [[buffer(0)]], constant int& uFirst
                         drawTileBackdrop = 0;
                         needNewAlphaTile = false;
                     }
-                    else
-                    {
-                        needNewAlphaTile = true;
-                    }
                 }
             }
             else
@@ -158,10 +154,10 @@ kernel void main0(constant int& uColumnCount [[buffer(0)]], constant int& uFirst
         }
         if (needNewAlphaTile)
         {
-            uint _306 = atomic_fetch_add_explicit((device atomic_uint*)&_303.iIndirectDrawParams[4], 1u, memory_order_relaxed);
-            uint drawBatchAlphaTileIndex = _306;
-            _310.iAlphaTiles[(drawBatchAlphaTileIndex * 2u) + 0u] = drawTileIndex;
-            _310.iAlphaTiles[(drawBatchAlphaTileIndex * 2u) + 1u] = uint(clipAlphaTileIndex);
+            uint _305 = atomic_fetch_add_explicit((device atomic_uint*)&_302.iIndirectDrawParams[4], 1u, memory_order_relaxed);
+            uint drawBatchAlphaTileIndex = _305;
+            _309.iAlphaTiles[(drawBatchAlphaTileIndex * 2u) + 0u] = drawTileIndex;
+            _309.iAlphaTiles[(drawBatchAlphaTileIndex * 2u) + 1u] = uint(clipAlphaTileIndex);
             drawAlphaTileIndex = int(drawBatchAlphaTileIndex) + uFirstAlphaTileIndex;
         }
         _175.iDrawTiles[(drawTileIndex * 4u) + 2u] = (uint(drawAlphaTileIndex) & 16777215u) | (uint(drawBackdropDelta) << uint(24));
@@ -170,12 +166,12 @@ kernel void main0(constant int& uColumnCount [[buffer(0)]], constant int& uFirst
         int tileMapIndex = (tileCoord_1.y * uFramebufferTileSize.x) + tileCoord_1.x;
         if ((zWrite && (drawTileBackdrop != 0)) && (drawAlphaTileIndex < 0))
         {
-            int _386 = atomic_fetch_max_explicit((device atomic_int*)&_381.iZBuffer[tileMapIndex], int(drawTileIndex), memory_order_relaxed);
+            int _385 = atomic_fetch_max_explicit((device atomic_int*)&_380.iZBuffer[tileMapIndex], int(drawTileIndex), memory_order_relaxed);
         }
         if ((drawTileBackdrop != 0) || (drawAlphaTileIndex >= 0))
         {
-            int _403 = atomic_exchange_explicit((device atomic_int*)&_398.iFirstTileMap[tileMapIndex], int(drawTileIndex), memory_order_relaxed);
-            int nextTileIndex = _403;
+            int _402 = atomic_exchange_explicit((device atomic_int*)&_397.iFirstTileMap[tileMapIndex], int(drawTileIndex), memory_order_relaxed);
+            int nextTileIndex = _402;
             _175.iDrawTiles[(drawTileIndex * 4u) + 0u] = uint(nextTileIndex);
         }
         currentBackdrop += drawBackdropDelta;

--- a/shaders/d3d11/propagate.cs.glsl
+++ b/shaders/d3d11/propagate.cs.glsl
@@ -148,11 +148,6 @@ void main() {
                                                         clipTileRect,
                                                         clipTileCoord);
 
-/*
-                clipAlphaTileIndex =
-                    int(iClipTiles[clipTileIndex * 4 +
-                                   TILE_FIELD_BACKDROP_ALPHA_TILE_ID] << 8) >> 8;
-                                   */
                 int thisClipAlphaTileIndex =
                     int(iClipTiles[clipTileIndex * 4 +
                                    TILE_FIELD_BACKDROP_ALPHA_TILE_ID] << 8) >> 8;
@@ -166,8 +161,8 @@ void main() {
                         needNewAlphaTile = true;
                     } else {
                         if (drawTileBackdrop != 0) {
-                            // This is a solid draw tile, but there's a clip applied. Replace it with an
-                            // alpha tile pointing directly to the clip mask.
+                            // This is a solid draw tile, but there's a clip applied. Replace it
+                            // with an alpha tile pointing directly to the clip mask.
                             drawAlphaTileIndex = thisClipAlphaTileIndex;
                             clipAlphaTileIndex = -1;
                             needNewAlphaTile = false;
@@ -184,8 +179,6 @@ void main() {
                         // This is a blank clip tile. Cull the draw tile entirely.
                         drawTileBackdrop = 0;
                         needNewAlphaTile = false;
-                    } else {
-                        needNewAlphaTile = true;
                     }
                 }
             } else {


### PR DESCRIPTION
Partially addresses #372.