### PR TITLE
Combine the Z-buffer and fill indirect draw params buffers to reduce the number of SSBO bindings.

### DIFF
--- a/renderer/src/gpu/d3d11/shaders.rs
+++ b/renderer/src/gpu/d3d11/shaders.rs
@@ -55,7 +55,6 @@ pub struct PropagateProgramD3D11<D> where D: Device {
     pub clip_tiles_storage_buffer: D::StorageBuffer,
     pub z_buffer_storage_buffer: D::StorageBuffer,
     pub first_tile_map_storage_buffer: D::StorageBuffer,
-    pub indirect_draw_params_storage_buffer: D::StorageBuffer,
     pub alpha_tiles_storage_buffer: D::StorageBuffer,
 }
 
@@ -75,9 +74,7 @@ impl<D> PropagateProgramD3D11<D> where D: Device {
         let clip_tiles_storage_buffer = device.get_storage_buffer(&program, "ClipTiles", 4);
         let z_buffer_storage_buffer = device.get_storage_buffer(&program, "ZBuffer", 5);
         let first_tile_map_storage_buffer = device.get_storage_buffer(&program, "FirstTileMap", 6);
-        let indirect_draw_params_storage_buffer =
-            device.get_storage_buffer(&program, "IndirectDrawParams", 7);
-        let alpha_tiles_storage_buffer = device.get_storage_buffer(&program, "AlphaTiles", 8);
+        let alpha_tiles_storage_buffer = device.get_storage_buffer(&program, "AlphaTiles", 7);
 
         PropagateProgramD3D11 {
             program,
@@ -91,7 +88,6 @@ impl<D> PropagateProgramD3D11<D> where D: Device {
             clip_tiles_storage_buffer,
             z_buffer_storage_buffer,
             first_tile_map_storage_buffer,
-            indirect_draw_params_storage_buffer,
             alpha_tiles_storage_buffer,
         }
     }

--- a/resources/shaders/gl4/d3d11/propagate.cs.glsl
+++ b/resources/shaders/gl4/d3d11/propagate.cs.glsl
@@ -29,6 +29,9 @@ layout(local_size_x = 64)in;
 
 
 
+
+
+
 uniform ivec2 uFramebufferTileSize;
 uniform int uColumnCount;
 uniform int uFirstAlphaTileIndex;
@@ -76,6 +79,12 @@ layout(std430, binding = 4)buffer bClipTiles {
 };
 
 layout(std430, binding = 5)buffer bZBuffer {
+
+
+
+
+
+
     restrict int iZBuffer[];
 };
 
@@ -83,16 +92,7 @@ layout(std430, binding = 6)buffer bFirstTileMap {
     restrict int iFirstTileMap[];
 };
 
-layout(std430, binding = 7)buffer bIndirectDrawParams {
-
-
-
-
-
-    restrict uint iIndirectDrawParams[];
-};
-
-layout(std430, binding = 8)buffer bAlphaTiles {
+layout(std430, binding = 7)buffer bAlphaTiles {
 
 
     restrict uint iAlphaTiles[];
@@ -191,7 +191,8 @@ void main(){
         }
 
         if(needNewAlphaTile){
-            uint drawBatchAlphaTileIndex = atomicAdd(iIndirectDrawParams[4], 1);
+            uint drawBatchAlphaTileIndex =
+                atomicAdd(iZBuffer[4], 1);
             iAlphaTiles[drawBatchAlphaTileIndex * 2 + 0]= drawTileIndex;
             iAlphaTiles[drawBatchAlphaTileIndex * 2 + 1]= clipAlphaTileIndex;
             drawAlphaTileIndex = int(drawBatchAlphaTileIndex)+ uFirstAlphaTileIndex;
@@ -206,7 +207,7 @@ void main(){
         ivec2 tileCoord = ivec2(tileX, tileY)+ ivec2(drawTileRect . xy);
         int tileMapIndex = tileCoord . y * uFramebufferTileSize . x + tileCoord . x;
         if(zWrite && drawTileBackdrop != 0 && drawAlphaTileIndex < 0)
-            atomicMax(iZBuffer[tileMapIndex], int(drawTileIndex));
+            atomicMax(iZBuffer[tileMapIndex + 8], int(drawTileIndex));
 
 
         if(drawTileBackdrop != 0 || drawAlphaTileIndex >= 0){

--- a/resources/shaders/gl4/d3d11/sort.cs.glsl
+++ b/resources/shaders/gl4/d3d11/sort.cs.glsl
@@ -25,6 +25,8 @@ precision highp float;
 
 
 
+
+
 uniform int uTileCount;
 
 layout(std430, binding = 0)buffer bTiles {
@@ -62,7 +64,7 @@ void main(){
     if(globalTileIndex >= uint(uTileCount))
         return;
 
-    int zValue = iZBuffer[globalTileIndex];
+    int zValue = iZBuffer[8 + globalTileIndex];
 
     int unsortedFirstTileIndex = getFirst(globalTileIndex);
     int sortedFirstTileIndex = - 1;

--- a/resources/shaders/metal/d3d11/sort.cs.metal
+++ b/resources/shaders/metal/d3d11/sort.cs.metal
@@ -48,7 +48,7 @@ kernel void main0(constant int& uTileCount [[buffer(2)]], device bFirstTileMap& 
     {
         return;
     }
-    int zValue = _76.iZBuffer[globalTileIndex];
+    int zValue = _76.iZBuffer[8u + globalTileIndex];
     uint param = globalTileIndex;
     int unsortedFirstTileIndex = getFirst(param, v_26);
     int sortedFirstTileIndex = -1;

--- a/shaders/d3d11/sort.cs.glsl
+++ b/shaders/d3d11/sort.cs.glsl
@@ -23,6 +23,8 @@ precision highp sampler2D;
 #define TILE_FIELD_BACKDROP_ALPHA_TILE_ID   2
 #define TILE_FIELD_CONTROL                  3
 
+#define FILL_INDIRECT_DRAW_PARAMS_SIZE      8
+
 uniform int uTileCount;
 
 layout(std430, binding = 0) buffer bTiles {
@@ -60,7 +62,7 @@ void main() {
     if (globalTileIndex >= uint(uTileCount))
         return;
 
-    int zValue = iZBuffer[globalTileIndex];
+    int zValue = iZBuffer[FILL_INDIRECT_DRAW_PARAMS_SIZE + globalTileIndex];
 
     int unsortedFirstTileIndex = getFirst(globalTileIndex);
     int sortedFirstTileIndex = -1;


### PR DESCRIPTION
Apparently Mesa RadeonSI drivers have a limit of 8 SSBOs.

Closes #373.