### PR TITLE
Make the fields of `TextMetrics` lazily calculated, and add an API that eliminates double layouts.

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -826,7 +826,7 @@ trait TextMetricsExt {
 
 impl TextMetricsExt for TextMetrics {
     fn to_c(&self) -> PFTextMetrics {
-        PFTextMetrics { width: self.width }
+        PFTextMetrics { width: self.width() }
     }
 }
 


### PR DESCRIPTION
This adds an extension to the HTML canvas API that allows you to pass the
`TextMetrics` object returned by `measure_text()` to `fill_text()` and/or
`stroke_text()` to draw the measured text without laying it out again. It
improves performance on the `canvas_nanovg` demo.