### PR TITLE
add reset method for CanvasRenderingContext2D

### DIFF
--- a/canvas/src/lib.rs
+++ b/canvas/src/lib.rs
@@ -164,6 +164,11 @@ impl CanvasRenderingContext2D {
     }
 
     // Extensions
+    pub fn reset(&mut self) {
+        self.saved_states = vec![];
+        self.current_state.reset();
+        self.clear();
+    }
 
     /// Clears the current canvas.
     pub fn clear(&mut self) {
@@ -677,6 +682,10 @@ impl State {
             global_composite_operation: CompositeOperation::SourceOver,
             clip_path: None,
         }
+    }
+
+    fn reset(&mut self) {
+        *self = State::default(self.font_collection.clone());
     }
 
     fn resolve_paint<'a>(&self, paint: &'a Paint) -> Cow<'a, Paint> {


### PR DESCRIPTION
In Web Browsers, If width or height of a Canvas reassigned, even the value not changed, the canvas would reset it's state, contains state stack and current properties.

```js
var canvas = new OffscreenCanvas(100, 100);
var ctx = canvas.getContext('2d')
ctx.font = 'menu'
console.log(ctx.font) // "16px Arial"
ctx.fillStyle = "red"
console.log(ctx.fillStyle) // "#ff0000"

// reassign width or height, the context state should reset to initial value
canvas.width = canvas.width
console.log(ctx.font) // "10px sans-serif"
console.log(ctx.fillStyle) // "#000000"
```