### PR TITLE
Passing actual color in fill attribute

### DIFF
--- a/export/src/lib.rs
+++ b/export/src/lib.rs
@@ -57,11 +57,13 @@ fn export_svg<W: Write>(scene: &Scene, writer: &mut W) -> io::Result<()> {
     for draw_path_index in 0..scene.draw_path_count() {
         let draw_path_id = DrawPathId(draw_path_index);
         let draw_path = scene.get_draw_path(draw_path_id);
+        let paint = scene.get_paint(draw_path.paint);
+
         write!(writer, "    <path")?;
         if !draw_path.name.is_empty() {
             write!(writer, " id=\"{}\"", draw_path.name)?;
         }
-        writeln!(writer, " fill=\"{:?}\" d=\"{:?}\" />", draw_path.paint, draw_path.outline)?;
+        writeln!(writer, " fill=\"{:?}\" d=\"{:?}\" />", paint.base_color(), draw_path.outline)?;
     }
     writeln!(writer, "</svg>")?;
     Ok(())


### PR DESCRIPTION
Presently, when serializing to SVG, the `fill` attribute is being populated with a `PaintId` identifier, e.g.:

```svg
<path fill="PaintId(1)" d="M 0 0 L 431.8 0 L 431.8 279.4 L 0 279.4 z" />
```

This PR instead utilizes the base color, which results in the following alternative output:

```svg
<path fill="#ffffff" d="M 0 0 L 431.8 0 L 431.8 279.4 L 0 279.4 z" />
```