### PR TITLE
Fix Cohen-Sutherland algorithm implementation for d3d9

### DIFF
--- a/content/src/clip.rs
+++ b/content/src/clip.rs
@@ -515,25 +515,25 @@ pub fn clip_line_segment_to_rect(mut line_segment: LineSegment2F, rect: RectF)
             point = vec2f(rect.min_x(),
                           lerp(line_segment.from_y(),
                                line_segment.to_y(),
-                               (line_segment.min_x() - line_segment.from_x()) /
-                                (line_segment.max_x() - line_segment.min_x())));
+                               (rect.min_x() - line_segment.from_x()) /
+                                   (line_segment.to_x() - line_segment.from_x())));
         } else if outcode.contains(Outcode::RIGHT) {
             point = vec2f(rect.max_x(),
                           lerp(line_segment.from_y(),
                                line_segment.to_y(),
-                               (line_segment.max_x() - line_segment.from_x()) /
-                                (line_segment.max_x() - line_segment.min_x())));
+                               (rect.max_x() - line_segment.from_x()) /
+                                   (line_segment.to_x() - line_segment.from_x())));
         } else if outcode.contains(Outcode::TOP) {
             point = vec2f(lerp(line_segment.from_x(),
                                line_segment.to_x(),
-                               (line_segment.min_y() - line_segment.from_y()) /
-                                (line_segment.max_y() - line_segment.min_y())),
+                               (rect.min_y() - line_segment.from_y()) /
+                                   (line_segment.to_y() - line_segment.from_y())),
                           rect.min_y());
         } else if outcode.contains(Outcode::BOTTOM) {
             point = vec2f(lerp(line_segment.from_x(),
                                line_segment.to_x(),
-                               (line_segment.max_y() - line_segment.from_y()) /
-                                (line_segment.max_y() - line_segment.min_y())),
+                               (rect.max_y() - line_segment.from_y()) /
+                                   (line_segment.to_y() - line_segment.from_y())),
                           rect.max_y());
         }
 


### PR DESCRIPTION
Fix the artifact caused by view box clipping on d3d9 level. Note that d3d11 doesn't have this issue.

![clipping_issue](https://user-images.githubusercontent.com/28705694/125883499-53ea8660-f7e2-43a5-ab27-8f820da9a05a.gif)