### PR TITLE
Contour: Print no-op parts for alternate debug format

### DIFF
--- a/content/src/outline.rs
+++ b/content/src/outline.rs
@@ -922,7 +922,12 @@ impl Contour {
 
 impl Debug for Contour {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        for (segment_index, segment) in self.iter(ContourIterFlags::IGNORE_CLOSE_SEGMENT)
+        let contour_flags = match formatter.alternate() {
+            false => ContourIterFlags::IGNORE_CLOSE_SEGMENT,
+            true => ContourIterFlags::empty(),
+        };
+
+        for (segment_index, segment) in self.iter(contour_flags)
                                             .enumerate() {
             if segment_index == 0 {
                 write!(


### PR DESCRIPTION
I'm working on a project where I'd like to print out the whole contour even if it's just a no-op (to maintain compatibility with an external project).  It looks like there's already code in place to allow this conditionally, so what I propose is that the alternate debug implementation prints the whole string while the default debug maintains the current behavior.

Thoughts?

Given:

```rust
let mut path = Path2D::new();
path.move_to(Vector2F::new(1., 1.));
let path_string = path.into_outline();
```

Expect:

```rust
assert_eq!(format!("{:?}", path_string), " z");

// This would be new behavior
assert_eq!(format!("{:#?}", path_string), "M 1 1 L 1 1 z");
```