### PR TITLE
Scale offset in source image's own coordinate space

### DIFF
--- a/canvas/src/lib.rs
+++ b/canvas/src/lib.rs
@@ -552,7 +552,7 @@ impl CanvasRenderingContext2D {
                                where I: CanvasImageSource, L: CanvasImageDestLocation {
         let dest_size = dest_location.size().unwrap_or(src_location.size());
         let scale = dest_size / src_location.size();
-        let offset = dest_location.origin() - src_location.origin();
+        let offset = dest_location.origin() - src_location.origin() * scale;
         let transform = Transform2F::from_scale(scale).translate(offset);
 
         let pattern = image.to_pattern(self, transform);


### PR DESCRIPTION
At present pathfinder_canvas treats the offset of sx/sy in draw_subimage as offsets in the destination canvas's coordinate space (See #481).

In order to match the behaviour of the html canvas API, these should be treated as offsets in the source image's coordinate space.

This fixes https://github.com/servo/pathfinder/issues/481. You can check the implementation against https://github.com/Adjective-Object/pathfinder_canvas_drawimage_repro.

For a quick visual reference, in these before/after images, the right side is made with the web canvas API In firefox, and the left side is the equivalent code in pathfinder_canvas.
Before:  ![image](https://user-images.githubusercontent.com/1174858/143279607-a862327d-e9e4-4fd3-8baf-09f7426772a8.png)
After:  ![image](https://user-images.githubusercontent.com/1174858/143279615-3504b1c9-b16b-4451-bc41-6978c22432ad.png)
