### PR TITLE
Add a capi feature to support current cargo-c

### DIFF
--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 edition = "2018"
 
+[features]
+capi = []
+
 [lib]
 crate-type = ["staticlib"]
 name = "pathfinder"


### PR DESCRIPTION
It also possibly simplifies the building instructions since it will pick automatically the crates in the workspace marked with a `capi` feature.