### PR TITLE
Handle even-odd fill rule for D3D11

### DIFF
--- a/resources/shaders/gl4/d3d11/bin.cs.glsl
+++ b/resources/shaders/gl4/d3d11/bin.cs.glsl
@@ -39,18 +39,18 @@ uniform int uMicrolineCount;
 
 uniform int uMaxFillCount;
 
-layout(std430, binding = 0)buffer bMicrolines {
-    restrict readonly uvec4 iMicrolines[];
+restrict readonly layout(std430, binding = 0)buffer bMicrolines {
+    uvec4 iMicrolines[];
 };
 
-layout(std430, binding = 1)buffer bMetadata {
+restrict readonly layout(std430, binding = 1)buffer bMetadata {
 
 
 
 
 
 
-    restrict readonly ivec4 iMetadata[];
+    ivec4 iMetadata[];
 };
 
 
@@ -58,27 +58,27 @@ layout(std430, binding = 1)buffer bMetadata {
 
 
 
-layout(std430, binding = 2)buffer bIndirectDrawParams {
-    restrict uint iIndirectDrawParams[];
+restrict layout(std430, binding = 2)buffer bIndirectDrawParams {
+    uint iIndirectDrawParams[];
 };
 
-layout(std430, binding = 3)buffer bFills {
-    restrict writeonly uint iFills[];
+restrict writeonly layout(std430, binding = 3)buffer bFills {
+    uint iFills[];
 };
 
-layout(std430, binding = 4)buffer bTiles {
+restrict layout(std430, binding = 4)buffer bTiles {
 
 
 
 
-    restrict uint iTiles[];
+    uint iTiles[];
 };
 
-layout(std430, binding = 5)buffer bBackdrops {
+restrict layout(std430, binding = 5)buffer bBackdrops {
 
 
 
-    restrict uint iBackdrops[];
+    uint iBackdrops[];
 };
 
 uint computeTileIndexNoCheck(ivec2 tileCoords, ivec4 pathTileRect, uint pathTileOffset){

--- a/resources/shaders/gl4/d3d11/bound.cs.glsl
+++ b/resources/shaders/gl4/d3d11/bound.cs.glsl
@@ -32,20 +32,20 @@ layout(local_size_x = 64)in;
 uniform int uPathCount;
 uniform int uTileCount;
 
-layout(std430, binding = 0)buffer bTilePathInfo {
+restrict readonly layout(std430, binding = 0)buffer bTilePathInfo {
 
 
 
 
-    restrict readonly uvec4 iTilePathInfo[];
+    uvec4 iTilePathInfo[];
 };
 
-layout(std430, binding = 1)buffer bTiles {
+restrict layout(std430, binding = 1)buffer bTiles {
 
 
 
 
-    restrict uint iTiles[];
+    uint iTiles[];
 };
 
 void main(){

--- a/resources/shaders/gl4/d3d11/dice.cs.glsl
+++ b/resources/shaders/gl4/d3d11/dice.cs.glsl
@@ -42,37 +42,37 @@ uniform int uPathCount;
 uniform int uLastBatchSegmentIndex;
 uniform int uMaxMicrolineCount;
 
-layout(std430, binding = 0)buffer bComputeIndirectParams {
+restrict layout(std430, binding = 0)buffer bComputeIndirectParams {
 
 
 
 
-    restrict uint iComputeIndirectParams[];
+    uint iComputeIndirectParams[];
 };
 
 
-layout(std430, binding = 1)buffer bDiceMetadata {
+restrict readonly layout(std430, binding = 1)buffer bDiceMetadata {
 
 
 
 
-    restrict readonly uvec4 iDiceMetadata[];
+    uvec4 iDiceMetadata[];
 };
 
-layout(std430, binding = 2)buffer bPoints {
-    restrict readonly vec2 iPoints[];
+restrict readonly layout(std430, binding = 2)buffer bPoints {
+    vec2 iPoints[];
 };
 
-layout(std430, binding = 3)buffer bInputIndices {
-    restrict readonly uvec2 iInputIndices[];
+restrict readonly layout(std430, binding = 3)buffer bInputIndices {
+    uvec2 iInputIndices[];
 };
 
-layout(std430, binding = 4)buffer bMicrolines {
+restrict layout(std430, binding = 4)buffer bMicrolines {
 
 
 
 
-    restrict uvec4 iMicrolines[];
+    uvec4 iMicrolines[];
 };
 
 void emitMicroline(vec4 microlineSegment, uint pathIndex, uint outputMicrolineIndex){

--- a/resources/shaders/gl4/d3d11/propagate.cs.glsl
+++ b/resources/shaders/gl4/d3d11/propagate.cs.glsl
@@ -32,70 +32,76 @@ layout(local_size_x = 64)in;
 
 
 
+
+
+
+
+
+
 uniform ivec2 uFramebufferTileSize;
 uniform int uColumnCount;
 uniform int uFirstAlphaTileIndex;
 
-layout(std430, binding = 0)buffer bDrawMetadata {
+restrict readonly layout(std430, binding = 0)buffer bDrawMetadata {
 
 
 
 
 
 
-    restrict readonly uvec4 iDrawMetadata[];
+    uvec4 iDrawMetadata[];
 };
 
-layout(std430, binding = 1)buffer bClipMetadata {
+restrict readonly layout(std430, binding = 1)buffer bClipMetadata {
 
 
 
 
 
-    restrict readonly uvec4 iClipMetadata[];
+    uvec4 iClipMetadata[];
 };
 
-layout(std430, binding = 2)buffer bBackdrops {
+restrict readonly layout(std430, binding = 2)buffer bBackdrops {
 
 
 
-    restrict readonly int iBackdrops[];
+    int iBackdrops[];
 };
 
-layout(std430, binding = 3)buffer bDrawTiles {
+restrict layout(std430, binding = 3)buffer bDrawTiles {
 
 
 
 
-    restrict uint iDrawTiles[];
+    uint iDrawTiles[];
 };
 
-layout(std430, binding = 4)buffer bClipTiles {
+restrict layout(std430, binding = 4)buffer bClipTiles {
 
 
 
 
-    restrict uint iClipTiles[];
+    uint iClipTiles[];
 };
 
-layout(std430, binding = 5)buffer bZBuffer {
+restrict layout(std430, binding = 5)buffer bZBuffer {
 
 
 
 
 
 
-    restrict int iZBuffer[];
+    int iZBuffer[];
 };
 
-layout(std430, binding = 6)buffer bFirstTileMap {
-    restrict int iFirstTileMap[];
+restrict layout(std430, binding = 6)buffer bFirstTileMap {
+    int iFirstTileMap[];
 };
 
-layout(std430, binding = 7)buffer bAlphaTiles {
+restrict layout(std430, binding = 7)buffer bAlphaTiles {
 
 
-    restrict uint iAlphaTiles[];
+    uint iAlphaTiles[];
 };
 
 uint calculateTileIndex(uint bufferOffset, uvec4 tileRect, uvec2 tileCoord){
@@ -202,6 +208,16 @@ void main(){
             (uint(drawAlphaTileIndex)& 0x00ffffffu)|(uint(drawBackdropDelta)<< 24);
         iDrawTiles[drawTileIndex * 4 + 3]=
             drawTileWord |(uint(drawTileBackdrop)<< 24);
+
+
+        if(drawTileBackdrop != 0){
+            int tileCtrl = int((drawTileWord >> 16)& 0xffu);
+            int maskCtrl =(tileCtrl >> 0)& 0x3;
+
+            if((maskCtrl & 0x2)!= 0 && mod(abs(drawTileBackdrop), 2)== 0){
+                zWrite = false;
+            }
+        }
 
 
         ivec2 tileCoord = ivec2(tileX, tileY)+ ivec2(drawTileRect . xy);

--- a/resources/shaders/gl4/d3d11/sort.cs.glsl
+++ b/resources/shaders/gl4/d3d11/sort.cs.glsl
@@ -29,20 +29,20 @@ precision highp float;
 
 uniform int uTileCount;
 
-layout(std430, binding = 0)buffer bTiles {
+restrict layout(std430, binding = 0)buffer bTiles {
 
 
 
 
-    restrict uint iTiles[];
+    uint iTiles[];
 };
 
-layout(std430, binding = 1)buffer bFirstTileMap {
-    restrict int iFirstTileMap[];
+restrict layout(std430, binding = 1)buffer bFirstTileMap {
+    int iFirstTileMap[];
 };
 
-layout(std430, binding = 2)buffer bZBuffer {
-    restrict readonly int iZBuffer[];
+restrict readonly layout(std430, binding = 2)buffer bZBuffer {
+    int iZBuffer[];
 };
 
 layout(local_size_x = 64)in;

--- a/resources/shaders/gl4/d3d11/tile.cs.glsl
+++ b/resources/shaders/gl4/d3d11/tile.cs.glsl
@@ -695,6 +695,12 @@ void computeTileVaryings(vec2 position,
 
 
 
+
+
+
+
+
+
 uniform int uLoadAction;
 uniform vec4 uClearColor;
 uniform vec2 uTileSize;
@@ -711,17 +717,17 @@ uniform vec2 uFramebufferSize;
 uniform ivec2 uFramebufferTileSize;
 layout(rgba8)uniform image2D uDestImage;
 
-layout(std430, binding = 0)buffer bTiles {
+restrict readonly layout(std430, binding = 0)buffer bTiles {
 
 
 
 
 
-    restrict readonly uint iTiles[];
+    uint iTiles[];
 };
 
-layout(std430, binding = 1)buffer bFirstTileMap {
-    restrict readonly int iFirstTileMap[];
+restrict readonly layout(std430, binding = 1)buffer bFirstTileMap {
+    int iFirstTileMap[];
 };
 
 uint calculateTileIndex(uint bufferOffset, uvec4 tileRect, uvec2 tileCoord){
@@ -772,6 +778,16 @@ void main(){
             } else {
 
                 backdrop = int(tileControlWord)>> 24;
+
+
+                if(backdrop != 0){
+                    int maskCtrl =(tileCtrl >> 0)& 0x3;
+
+                    if((maskCtrl & 0x2)!= 0 && mod(abs(backdrop), 2)== 0){
+                        break;
+                    }
+                }
+
                 maskTileCoord = uvec2(0u);
                 tileCtrl &= ~(0x3 << 0);
             }

--- a/resources/shaders/metal/d3d11/bin.cs.metal
+++ b/resources/shaders/metal/d3d11/bin.cs.metal
@@ -150,8 +150,8 @@ kernel void main0(constant int& uMaxFillCount [[buffer(2)]], constant int& uMicr
     uint pathIndex = param_1;
     float4 lineSegment = _354;
     int4 pathTileRect = _360.iMetadata[(pathIndex * 3u) + 0u];
-    uint pathTileOffset = uint(_360.iMetadata[(pathIndex * 3u) + 1u].x);
-    uint pathBackdropOffset = uint(_360.iMetadata[(pathIndex * 3u) + 2u].x);
+    uint pathTileOffset = uint(((device int*)&_360.iMetadata[(pathIndex * 3u) + 1u])[0u]);
+    uint pathBackdropOffset = uint(((device int*)&_360.iMetadata[(pathIndex * 3u) + 2u])[0u]);
     int2 tileSize = int2(16);
     int4 tileLineSegment = int4(floor(lineSegment / float4(tileSize.xyxy)));
     int2 fromTileCoords = tileLineSegment.xy;

--- a/resources/shaders/metal/d3d11/bound.cs.metal
+++ b/resources/shaders/metal/d3d11/bound.cs.metal
@@ -41,7 +41,7 @@ kernel void main0(constant int& uTileCount [[buffer(0)]], constant int& uPathCou
         if (_50)
         {
             uint midPathIndex = lowPathIndex + ((highPathIndex - lowPathIndex) / 2u);
-            uint midTileIndex = _64.iTilePathInfo[midPathIndex].z;
+            uint midTileIndex = ((device uint*)&_64.iTilePathInfo[midPathIndex])[2u];
             if (tileIndex < midTileIndex)
             {
                 highPathIndex = midPathIndex;

--- a/resources/shaders/metal/d3d11/dice.cs.metal
+++ b/resources/shaders/metal/d3d11/dice.cs.metal
@@ -100,7 +100,7 @@ kernel void main0(constant int& uMaxMicrolineCount [[buffer(0)]], constant int& 
         if (_241)
         {
             uint midPathIndex = lowPathIndex + ((highPathIndex - lowPathIndex) / 2u);
-            uint midBatchSegmentIndex = _253.iDiceMetadata[midPathIndex].z;
+            uint midBatchSegmentIndex = ((device uint*)&_253.iDiceMetadata[midPathIndex])[2u];
             if (batchSegmentIndex < midBatchSegmentIndex)
             {
                 highPathIndex = midPathIndex;

--- a/resources/shaders/metal/d3d11/tile.cs.metal
+++ b/resources/shaders/metal/d3d11/tile.cs.metal
@@ -729,6 +729,24 @@ kernel void main0(constant int2& uFramebufferTileSize [[buffer(3)]], constant in
             else
             {
                 backdrop = int(tileControlWord) >> 24;
+                if (backdrop != 0)
+                {
+                    int maskCtrl = (tileCtrl >> 0) & 3;
+                    bool _1751 = (maskCtrl & 2) != 0;
+                    bool _1759;
+                    if (_1751)
+                    {
+                        _1759 = mod(float(abs(backdrop)), 2.0) == 0.0;
+                    }
+                    else
+                    {
+                        _1759 = _1751;
+                    }
+                    if (_1759)
+                    {
+                        break;
+                    }
+                }
                 maskTileCoord = uint2(0u);
                 tileCtrl &= (-4);
             }

--- a/shaders/d3d11/bin.cs.glsl
+++ b/shaders/d3d11/bin.cs.glsl
@@ -37,18 +37,18 @@ uniform int uMicrolineCount;
 // How many slots we have allocated for fills.
 uniform int uMaxFillCount;
 
-layout(std430, binding = 0) buffer bMicrolines {
-    restrict readonly uvec4 iMicrolines[];
+restrict readonly layout(std430, binding = 0) buffer bMicrolines {
+    uvec4 iMicrolines[];
 };
 
-layout(std430, binding = 1) buffer bMetadata {
+restrict readonly layout(std430, binding = 1) buffer bMetadata {
     // [0]: tile rect
     // [1].x: tile offset
     // [1].y: path ID
     // [1].z: z write flag
     // [1].w: clip path ID
     // [2].x: backdrop offset
-    restrict readonly ivec4 iMetadata[];
+    ivec4 iMetadata[];
 };
 
 // [0]: vertexCount (6)
@@ -56,27 +56,27 @@ layout(std430, binding = 1) buffer bMetadata {
 // [2]: vertexStart (0)
 // [3]: baseInstance (0)
 // [4]: alpha tile count
-layout(std430, binding = 2) buffer bIndirectDrawParams {
-    restrict uint iIndirectDrawParams[];
+restrict layout(std430, binding = 2) buffer bIndirectDrawParams {
+    uint iIndirectDrawParams[];
 };
 
-layout(std430, binding = 3) buffer bFills {
-    restrict writeonly uint iFills[];
+restrict writeonly layout(std430, binding = 3) buffer bFills {
+    uint iFills[];
 };
 
-layout(std430, binding = 4) buffer bTiles {
+restrict layout(std430, binding = 4) buffer bTiles {
     // [0]: next tile ID (initialized to -1)
     // [1]: first fill ID (initialized to -1)
     // [2]: backdrop delta upper 8 bits, alpha tile ID lower 24 (initialized to 0, -1 respectively)
     // [3]: color/ctrl/backdrop word
-    restrict uint iTiles[];
+    uint iTiles[];
 };
 
-layout(std430, binding = 5) buffer bBackdrops {
+restrict layout(std430, binding = 5) buffer bBackdrops {
     // [0]: backdrop
     // [1]: tile X offset
     // [2]: path ID
-    restrict uint iBackdrops[];
+    uint iBackdrops[];
 };
 
 uint computeTileIndexNoCheck(ivec2 tileCoords, ivec4 pathTileRect, uint pathTileOffset) {

--- a/shaders/d3d11/bound.cs.glsl
+++ b/shaders/d3d11/bound.cs.glsl
@@ -30,20 +30,20 @@ layout(local_size_x = 64) in;
 uniform int uPathCount;
 uniform int uTileCount;
 
-layout(std430, binding = 0) buffer bTilePathInfo {
+restrict readonly layout(std430, binding = 0) buffer bTilePathInfo {
     // x: tile upper left, 16-bit packed x/y
     // y: tile lower right, 16-bit packed x/y
     // z: first tile index in this path
     // w: color/ctrl/backdrop word
-    restrict readonly uvec4 iTilePathInfo[];
+    uvec4 iTilePathInfo[];
 };
 
-layout(std430, binding = 1) buffer bTiles {
+restrict layout(std430, binding = 1) buffer bTiles {
     // [0]: next tile ID (initialized to -1)
     // [1]: first fill ID (initialized to -1)
     // [2]: backdrop delta upper 8 bits, alpha tile ID lower 24 (initialized to 0, -1 respectively)
     // [3]: color/ctrl/backdrop word
-    restrict uint iTiles[];
+    uint iTiles[];
 };
 
 void main() {

--- a/shaders/d3d11/dice.cs.glsl
+++ b/shaders/d3d11/dice.cs.glsl
@@ -40,37 +40,37 @@ uniform int uPathCount;
 uniform int uLastBatchSegmentIndex;
 uniform int uMaxMicrolineCount;
 
-layout(std430, binding = 0) buffer bComputeIndirectParams {
+restrict layout(std430, binding = 0) buffer bComputeIndirectParams {
     // [0]: number of x workgroups
     // [1]: number of y workgroups (always 1)
     // [2]: number of z workgroups (always 1)
     // [3]: number of output microlines
-    restrict uint iComputeIndirectParams[];
+    uint iComputeIndirectParams[];
 };
 
 // Indexed by batch path index.
-layout(std430, binding = 1) buffer bDiceMetadata {
+restrict readonly layout(std430, binding = 1) buffer bDiceMetadata {
     // x: global path ID
     // y: first global segment index
     // z: first batch segment index
     // w: unused
-    restrict readonly uvec4 iDiceMetadata[];
+    uvec4 iDiceMetadata[];
 };
 
-layout(std430, binding = 2) buffer bPoints {
-    restrict readonly vec2 iPoints[];
+restrict readonly layout(std430, binding = 2) buffer bPoints {
+    vec2 iPoints[];
 };
 
-layout(std430, binding = 3) buffer bInputIndices {
-    restrict readonly uvec2 iInputIndices[];
+restrict readonly layout(std430, binding = 3) buffer bInputIndices {
+    uvec2 iInputIndices[];
 };
 
-layout(std430, binding = 4) buffer bMicrolines {
+restrict layout(std430, binding = 4) buffer bMicrolines {
     // x: from (X, Y) whole pixels, packed signed 16-bit
     // y: to (X, Y) whole pixels, packed signed 16-bit
     // z: (from X, from Y, to X, to Y) fractional pixels, packed unsigned 8-bit (0.8 fixed point)
     // w: path ID
-    restrict uvec4 iMicrolines[];
+    uvec4 iMicrolines[];
 };
 
 void emitMicroline(vec4 microlineSegment, uint pathIndex, uint outputMicrolineIndex) {

--- a/shaders/d3d11/sort.cs.glsl
+++ b/shaders/d3d11/sort.cs.glsl
@@ -27,20 +27,20 @@ precision highp sampler2D;
 
 uniform int uTileCount;
 
-layout(std430, binding = 0) buffer bTiles {
+restrict layout(std430, binding = 0) buffer bTiles {
     // [0]: next tile ID
     // [1]: first fill ID
     // [2]: backdrop delta upper 8 bits, alpha tile ID lower 24
     // [3]: color/ctrl/backdrop word
-    restrict uint iTiles[];
+    uint iTiles[];
 };
 
-layout(std430, binding = 1) buffer bFirstTileMap {
-    restrict int iFirstTileMap[];
+restrict layout(std430, binding = 1) buffer bFirstTileMap {
+    int iFirstTileMap[];
 };
 
-layout(std430, binding = 2) buffer bZBuffer {
-    restrict readonly int iZBuffer[];
+restrict readonly layout(std430, binding = 2) buffer bZBuffer {
+    int iZBuffer[];
 };
 
 layout(local_size_x = 64) in;


### PR DESCRIPTION
Before
<img width="797" alt="before" src="https://user-images.githubusercontent.com/28705694/168966989-47ee0bb0-7f4d-4a85-ada6-ef428187818b.png">

After
<img width="798" alt="after" src="https://user-images.githubusercontent.com/28705694/168967026-53bd7a70-92f8-41a4-9004-cb0f40dcbc97.png">

Some complex scenarios had been tested and no problem was found.

Inkscape
<img width="509" alt="image" src="https://user-images.githubusercontent.com/28705694/168967836-11d2c82c-8d76-4bcb-b798-da21217970d6.png">


Pathfinder
<img width="797" alt="image" src="https://user-images.githubusercontent.com/28705694/168967783-28a035c4-e954-409f-9f74-b23a46e8475d.png">
