### PR TITLE
fix f32x4_basic_ops test

### DIFF
--- a/simd/src/test.rs
+++ b/simd/src/test.rs
@@ -37,7 +37,7 @@ fn test_f32x4_accessors_and_mutators() {
 fn test_f32x4_basic_ops() {
     let a = F32x4::new(1.0, 3.0, 5.0, 7.0);
     let b = F32x4::new(2.0, 2.0, 6.0, 6.0);
-    assert_eq!(a.approx_recip(), F32x4::new(0.99975586, 0.33325195, 0.19995117, 0.14282227));
+    assert_eq!(a.approx_recip(), F32x4::new(0.99975586, 0.333313, 0.19995117, 0.14282227));
     assert_eq!(a.min(b), F32x4::new(1.0, 2.0, 5.0, 6.0));
     assert_eq!(a.max(b), F32x4::new(2.0, 3.0, 6.0, 7.0));
     let c = F32x4::new(-1.0, 1.3, -20.0, 3.6);


### PR DESCRIPTION
The test function body is probably incorrect. The right-hand side produces values which are incorrect in the CI run as well. Everything else seems to be fine.

This can be verified when using only the simd intrinsics as defined in the [core library](https://rust-lang.github.io/stdarch/x86_64/core_arch/x86_64/fn._mm_rcp_ps.html).

```rust
fn main() {
    #[cfg(target_arch = "x86")]
    use std::arch::x86::*;
    #[cfg(target_arch = "x86_64")]
    use std::arch::x86_64::*;

    unsafe {
        let values = _mm_set_ps(1.0, 3.0, 5.0, 7.0);
        let res = _mm_rcp_ps(values);
        println!("{:?}", values);
        println!("{:?}", res);
    }
}
```
produces
```bash
__m128(7.0, 5.0, 3.0, 1.0)
__m128(0.14282227, 0.19995117, 0.333313, 0.99975586)
```
Notice that the order in the output is different compared to its specification inline but the result is correct.

We obtain the same results when using this small C programm:
```C
#include <stdio.h>

#ifdef __SSE2__
    #include <emmintrin.h>
#else
    #warning SSE2 suport is not available. Code will not compile
#endif

int main() {
    __m128 a = _mm_set_ps(1.0, 3.0, 5.0, 7.0);
    __m128 b = _mm_rcp_ps(a);

    float c[4];
    _mm_storeu_ps(c, b);

    printf("%f %f %f %f\n", c[0], c[1], c[2], c[3]);
    return 0;
}
```
Compile with gcc and run
```bash
$ gcc main.c -o main
$ ./main
>> 0.142822 0.199951 0.333313 0.999756
```
