### PR TITLE
bump simd to 0.5.3 in order push fixes for stdsimd feature upstream

### DIFF
--- a/simd/Cargo.toml
+++ b/simd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder_simd"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 build = "build.rs"


### PR DESCRIPTION
This is a follow-up of #548 to push simd upstream.