### PR TITLE
Rename simd_fmin/simd_fmax

### DIFF
--- a/simd/src/arm/mod.rs
+++ b/simd/src/arm/mod.rs
@@ -79,12 +79,12 @@ impl F32x2 {
 
     #[inline]
     pub fn min(self, other: F32x2) -> F32x2 {
-        unsafe { F32x2(simd_fmin(self.0, other.0)) }
+        unsafe { F32x2(simd_minimum_number_nsz(self.0, other.0)) }
     }
 
     #[inline]
     pub fn max(self, other: F32x2) -> F32x2 {
-        unsafe { F32x2(simd_fmax(self.0, other.0)) }
+        unsafe { F32x2(simd_maximum_number_nsz(self.0, other.0)) }
     }
 
     #[inline]
@@ -268,12 +268,12 @@ impl F32x4 {
 
     #[inline]
     pub fn min(self, other: F32x4) -> F32x4 {
-        unsafe { F32x4(simd_fmin(self.0, other.0)) }
+        unsafe { F32x4(simd_minimum_number_nsz(self.0, other.0)) }
     }
 
     #[inline]
     pub fn max(self, other: F32x4) -> F32x4 {
-        unsafe { F32x4(simd_fmax(self.0, other.0)) }
+        unsafe { F32x4(simd_maximum_number_nsz(self.0, other.0)) }
     }
 
     #[inline]
@@ -604,12 +604,12 @@ impl I32x4 {
 
     #[inline]
     pub fn max(self, other: I32x4) -> I32x4 {
-        unsafe { I32x4(simd_cast(simd_fmax(self.to_f32x4().0, other.to_f32x4().0))) }
+        unsafe { I32x4(simd_cast(simd_maximum_number_nsz(self.to_f32x4().0, other.to_f32x4().0))) }
     }
 
     #[inline]
     pub fn min(self, other: I32x4) -> I32x4 {
-        unsafe { I32x4(simd_cast(simd_fmin(self.to_f32x4().0, other.to_f32x4().0))) }
+        unsafe { I32x4(simd_cast(simd_minimum_number_nsz(self.to_f32x4().0, other.to_f32x4().0))) }
     }
 
     // Packed comparisons


### PR DESCRIPTION
This change follows the change made in https://github.com/rust-lang/rust/pull/154043 by renaming simd_fmin to simd_minimum_number_nsz and simd_fmax to simd_maximum_number_nsz

This will fix #584 that caused breaking builds on nightly-2026-03-31 and later