### PR TITLE
Bump pathfinder_simd from 0.5.5 to 0.5.6

### DIFF
--- a/simd/Cargo.toml
+++ b/simd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2018"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 build = "build.rs"


### PR DESCRIPTION
Includes:

https://github.com/servo/pathfinder/pull/581

https://github.com/servo/pathfinder/pull/583